### PR TITLE
Skip directory when recursive get

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1621,6 +1621,8 @@ class AzureBlobFileSystem(AsyncFileSystem):
         self, rpath, lpath, recursive=False, delimiter="/", callback=None, **kwargs
     ):
         """ Copy single file remote to local """
+        if os.path.isdir(lpath):
+            return
         container_name, path = self.split_path(rpath, delimiter=delimiter)
         try:
             async with self.service_client.get_blob_client(


### PR DESCRIPTION
As described in #284, `IsADirectoryError` is raised when trying to get recursively a directory from Azure Blob Storage. This PR add a check to `_get_file` method, which avoids opening a directory with `open`.