### PR TITLE
Pass azurite url error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 2022.04.0
 ---------
 - Added support for Python 3.10 and pinned Python 3.8
-- Updated requirements/latest.txt azure-storage-blob due to header failures in azurite
+- Skip test_url due to bug in Azurite
 - Added isort and update pre-commit
 
 v2022.02.0

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1262,6 +1262,7 @@ def test_cat_file_missing(storage):
         fs.cat_file("does/not/exist")
 
 
+@pytest.mark.skip(reason="Bug in Azurite Storage Emulator v3.15.0 gives 403 status_code")
 def test_url(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR, account_key=KEY

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1262,7 +1262,9 @@ def test_cat_file_missing(storage):
         fs.cat_file("does/not/exist")
 
 
-@pytest.mark.skip(reason="Bug in Azurite Storage Emulator v3.15.0 gives 403 status_code")
+@pytest.mark.skip(
+    reason="Bug in Azurite Storage Emulator v3.15.0 gives 403 status_code"
+)
 def test_url(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR, account_key=KEY

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,7 +2,7 @@
 git+https://github.com/intake/filesystem_spec
 azure-core
 azure-datalake-store
-azure-storage-blob<12.10.0
+azure-storage-blob
 black
 flake8
 isort

--- a/requirements/latest.txt
+++ b/requirements/latest.txt
@@ -2,4 +2,4 @@
 fsspec
 azure-core
 azure-datalake-store
-azure-storage-blob<12.10.0
+azure-storage-blob

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "azure-core>=1.7.0",
         "azure-datalake-store>=0.0.46,<0.1",
         "azure-identity",
-        "azure-storage-blob>=12.5.0,<12.10.0",
+        "azure-storage-blob>=12.5.0",
         "fsspec>=2021.10.1",
     ],
     extras_require={


### PR DESCRIPTION
After testing testing fs.url() against a live Azure Storage Account, marking `test_url` as skipped.