### PR TITLE
Fix info() performance

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -645,12 +645,6 @@ class AzureBlobFileSystem(AsyncFileSystem):
         else:
             invalidate_cache = False
         path = self._strip_protocol(path)
-        out = await self._ls(
-            self._parent(path), invalidate_cache=invalidate_cache, **kwargs
-        )
-        out = [o for o in out if o["name"].rstrip("/") == path]
-        if out:
-            return out[0]
         out = await self._ls(path, invalidate_cache=invalidate_cache, **kwargs)
         path = path.rstrip("/")
         out1 = [o for o in out if o["name"].rstrip("/") == path]
@@ -661,7 +655,15 @@ class AzureBlobFileSystem(AsyncFileSystem):
         elif len(out1) > 1 or out:
             return {"name": path, "size": None, "type": "directory"}
         else:
-            raise FileNotFoundError
+            # Check the directory listing as the path may have been deleted
+            out = await self._ls(
+                self._parent(path), invalidate_cache=invalidate_cache, **kwargs
+            )
+            out = [o for o in out if o["name"].rstrip("/") == path]
+            if out:
+                return out[0]
+            else:
+                raise FileNotFoundError
 
     def glob(self, path, **kwargs):
         return sync(self.loop, self._glob, path)


### PR DESCRIPTION
This reorders the behavior of fs.info() so that it now searches the
parent directory for the entry after trying to find the item directly.
This is because scanning the parent directory is O(N) with the number of
items in the directory.

Fixes #248 