### PR TITLE
Update `AzureBlobFileSystem` docstrings

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -359,7 +359,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
 
     Authentication with an account_key
 
-    >>> abfs = AzureBlobFileSystem(account_name="XXXX", account_key="XXXX", container_name="XXXX")
+    >>> abfs = AzureBlobFileSystem(account_name="XXXX", account_key="XXXX")
     >>> abfs.ls('')
 
     Authentication with an Azure ServicePrincipal


### PR DESCRIPTION
I was checking `AzureBlobFileSystem` docstrings in order to play around with it and I found out that in the docstrings it says that one authentication method allows you to provide not just the `account_name` and `account_key` but also the `container_name`.

So on, I removed the `container_name` arg from the docstring as when calling `abfs.ls("")` the output is not the listing of the container's directory, but the listing of all the containers in the account, so the `container_name` arg won't have any use there, as in order to list all the blobs of a container we could just `abfs.ls("container_name")`.