### PR TITLE
Fix unit tests as an `AssertionError` was triggered while listing the metadata

### DIFF
--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -939,6 +939,7 @@ def test_dask_parquet(storage):
             "{}://test/test_group.parquet".format(protocol),
             storage_options=STORAGE_OPTIONS,
             engine="pyarrow",
+            write_metadata_file=True,
         )
 
         fs = AzureBlobFileSystem(**STORAGE_OPTIONS)
@@ -964,6 +965,7 @@ def test_dask_parquet(storage):
         "abfs://test/test_group2.parquet",
         storage_options=STORAGE_OPTIONS,
         engine="pyarrow",
+        write_metadata_file=True,
     )
     assert fs.ls("test/test_group2.parquet") == [
         "test/test_group2.parquet/_common_metadata",
@@ -993,6 +995,7 @@ def test_dask_parquet(storage):
         partition_on=["A", "B"],
         storage_options=STORAGE_OPTIONS,
         engine="pyarrow",
+        write_metadata_file=True,
     )
     assert fs.glob("test/test_group3.parquet/*") == [
         "test/test_group3.parquet/A=1",
@@ -1019,6 +1022,7 @@ def test_dask_parquet(storage):
         engine="pyarrow",
         flavor="spark",
         write_statistics=False,
+        write_metadata_file=True,
     )
     fs.rmdir("test/test_group4.parquet/_common_metadata", recursive=True)
     fs.rmdir("test/test_group4.parquet/_metadata", recursive=True)
@@ -1045,6 +1049,7 @@ def test_dask_parquet(storage):
         "abfs://test/test group5.parquet",
         storage_options=STORAGE_OPTIONS,
         engine="pyarrow",
+        write_metadata_file=True,
     )
     assert fs.ls("test/test group5.parquet") == [
         "test/test group5.parquet/_common_metadata",

--- a/adlfs/tests/test_uri_format.py
+++ b/adlfs/tests/test_uri_format.py
@@ -34,6 +34,7 @@ def test_dask_parquet(storage):
             "{}://test@dfs.core.windows.net/test_group.parquet".format(protocol),
             storage_options=STORAGE_OPTIONS,
             engine="pyarrow",
+            write_metadata_file=True,
         )
 
         fs = AzureBlobFileSystem(**STORAGE_OPTIONS)


### PR DESCRIPTION
When I created a PR for `adlfs` at https://github.com/fsspec/adlfs/pull/323 I found out that the unit tests triggered by `azure-pipelines.yml` were failing not just for my PR but for all the other PRs, and since mine just changed a docstring, that means that the unit tests were failing before.

So I did a little bit of research and found out that in the stable version of Dask as explained at https://docs.dask.org/en/stable/generated/dask.dataframe.to_parquet.html#dask.dataframe.to_parquet, you need to manually set the value for `write_metadata_file` when calling `.to_parquet` so that not just the parquet files are written, but also the metadata (both `_metadata` and `_common_metadata` directories).

So on, adding the parameter `write_metadata_file=True` in all the `.to_parquet` calls fixes the issue, and the tests are passing again.