### PR TITLE
Rename `main` branch to `master` on trigger for `docs.yaml`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Docs
 on:
   push:
     branches:    
-      - main
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
According to the following statement https://sfconservancy.org/news/2020/jun/23/gitbranchname/, the Git main branch should be renamed from `master` to `main`, as it can be considered offensive. So it makes sense to rename those, but the current trigger on `docs.yaml` is just being triggered when you push changes to the `main` branch, but since this repository still names its main branch as `master`, it won't be triggered automatically.

So in the meanwhile, I renamed the trigger condition on push back to `master` so that it's triggered when changes are pushed to it, otherwise, it wouldn't be triggered.

Additionally, as there are not many PRs ongoing it may be a nice moment to rename `master` to `main` with `git branch -m master main`, and start using the `main` branch instead.