### PR TITLE
Parse AzureBlobFileSystem account_name in URI

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -7,6 +7,7 @@ import asyncio
 import io
 import logging
 import os
+import re
 import warnings
 import weakref
 from datetime import datetime, timedelta
@@ -487,6 +488,21 @@ class AzureBlobFileSystem(AsyncFileSystem):
 
         logger.debug(f"_strip_protocol({path}) = {ops}")
         return ops["path"]
+
+    @staticmethod
+    def _get_kwargs_from_urls(urlpath):
+        """Get the account_name from the urlpath and pass to storage_options"""
+        ops = infer_storage_options(urlpath)
+        out = {}
+        host = ops.get("host", None)
+        if host:
+            match = re.match(
+                r"(?P<account_name>.+)\.(dfs|blob)\.core\.windows\.net", host
+            )
+            if match:
+                account_name = match.groupdict()["account_name"]
+                out["account_name"] = account_name
+        return out
 
     def _get_credential_from_service_principal(self):
         """

--- a/adlfs/tests/test_uri_format.py
+++ b/adlfs/tests/test_uri_format.py
@@ -51,3 +51,10 @@ def test_dask_parquet(storage):
         engine="pyarrow",
     ).compute()
     assert_frame_equal(df, df_test)
+
+
+def test_account_name_from_url():
+    kwargs = AzureBlobFileSystem._get_kwargs_from_urls(
+        "abfs://test@some_account_name.dfs.core.windows.net/some_file"
+    )
+    assert kwargs["account_name"] == "some_account_name"


### PR DESCRIPTION
Before this PR, one needs to manually specify `account_name` to `storage_options` when opening a file from Blob Storage with fsspec.

```python
import fsspec

# ok
with fsspec.open("abfs://test@some_account_name.dfs.core.windows.net/some_file", account_name="") as f:
   ...

# fails
with fsspec.open("abfs://test@some_account_name.dfs.core.windows.net/some_file") as f:
   ...
```

However, the account name can be part of the URI, as specified by [Azure's doc](https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri#uri-syntax).

This PR allows the user not to specify `account_name` to `storage_options` when it is in the URI

```python
import fsspec

# ok
with fsspec.open("abfs://test@some_account_name.dfs.core.windows.net/some_file", account_name="") as f:
   ...

# ok
with fsspec.open("abfs://test@some_account_name.dfs.core.windows.net/some_file") as f:
   ...
```