### PR TITLE
abfs: support blob storage versioning

### DIFF
--- a/adlfs/tests/conftest.py
+++ b/adlfs/tests/conftest.py
@@ -59,9 +59,13 @@ def storage(host):
 
 @pytest.fixture(scope="session")
 def event_loop():
-    loop = asyncio.get_event_loop()
-    yield loop
-    loop.close()
+    policy = asyncio.get_event_loop_policy()
+    loop = policy.new_event_loop()
+    try:
+        yield loop
+    finally:
+        loop.close()
+        policy.set_event_loop(loop)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -15,6 +15,8 @@ URL = "http://127.0.0.1:10000"
 ACCOUNT_NAME = "devstoreaccount1"
 KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="  # NOQA
 CONN_STR = f"DefaultEndpointsProtocol=http;AccountName={ACCOUNT_NAME};AccountKey={KEY};BlobEndpoint={URL}/{ACCOUNT_NAME};"  # NOQA
+DEFAULT_VERSION_ID = "1970-01-01T00:00:00.0000000Z"
+LATEST_VERSION_ID = "2022-01-01T00:00:00.0000000Z"
 
 
 def assert_almost_equal(x, y, threshold, prop_name=None):
@@ -263,6 +265,31 @@ def test_ls_no_listings_cache(storage):
     )
     result = fs.ls("data/root")
     assert len(result) > 0  # some state leaking between tests
+
+
+async def test_ls_versioned(storage, mocker):
+    from azure.storage.blob.aio import ContainerClient
+
+    walk_blobs = mocker.patch.object(ContainerClient, "walk_blobs")
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        version_aware=False,
+        skip_instance_cache=True,
+    )
+    with pytest.raises(ValueError):
+        await fs._ls("data/root/a/file.txt", version_id=DEFAULT_VERSION_ID)
+    await fs._ls("data/root/a/file.txt")
+    walk_blobs.assert_called_once_with(
+        include=["metadata"], name_starts_with="root/a/file.txt"
+    )
+
+    fs.version_aware = True
+    walk_blobs.reset_mock()
+    await fs._ls("data/root/a/file.txt", version_id=DEFAULT_VERSION_ID)
+    walk_blobs.assert_called_once_with(
+        include=["metadata", "versions"], name_starts_with="root/a/file.txt"
+    )
 
 
 def test_info(storage):
@@ -1258,6 +1285,26 @@ def test_isfile(storage):
     assert fs.isfile("data/root/null_file.txt") is True
 
 
+async def test_isfile_versioned(storage, mocker):
+    from azure.core.exceptions import HttpResponseError
+    from azure.storage.blob.aio import BlobClient
+
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        version_aware=True,
+        skip_instance_cache=True,
+    )
+    get_blob_properties = mocker.patch.object(BlobClient, "get_blob_properties")
+
+    await fs._isfile(f"data/root/a/file.txt?versionid={DEFAULT_VERSION_ID}")
+    get_blob_properties.assert_called_once_with(version_id=DEFAULT_VERSION_ID)
+
+    get_blob_properties.reset_mock()
+    get_blob_properties.side_effect = HttpResponseError
+    assert not await fs._isfile("data/root/a/file.txt?versionid=invalid_version")
+
+
 def test_isdir(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR
@@ -1331,6 +1378,29 @@ def test_cat_file_missing(storage):
         fs.cat_file("does/not/exist")
 
 
+async def test_cat_file_versioned(storage, mocker):
+    from azure.core.exceptions import HttpResponseError
+    from azure.storage.blob.aio import BlobClient
+
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        version_aware=True,
+        skip_instance_cache=True,
+    )
+    download_blob = mocker.patch.object(BlobClient, "download_blob")
+
+    await fs._cat_file(f"data/root/a/file.txt?versionid={DEFAULT_VERSION_ID}")
+    download_blob.assert_called_once_with(
+        offset=None, length=None, version_id=DEFAULT_VERSION_ID
+    )
+
+    download_blob.reset_mock()
+    download_blob.side_effect = HttpResponseError
+    with pytest.raises(FileNotFoundError):
+        await fs._cat_file("data/root/a/file.txt?versionid=invalid_version")
+
+
 @pytest.mark.skip(
     reason="Bug in Azurite Storage Emulator v3.15.0 gives 403 status_code"
 )
@@ -1352,6 +1422,28 @@ def test_url(storage):
     fs.rm("catdir/catfile.txt")
 
 
+async def test_url_versioned(storage, mocker):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        account_key=KEY,
+        version_aware=True,
+        skip_instance_cache=True,
+    )
+    generate_blob_sas = mocker.patch("adlfs.spec.generate_blob_sas")
+
+    await fs._url(f"data/root/a/file.txt?versionid={DEFAULT_VERSION_ID}")
+    generate_blob_sas.assert_called_once_with(
+        account_name=storage.account_name,
+        container_name="data",
+        blob_name="root/a/file.txt",
+        account_key=KEY,
+        permission=mocker.ANY,
+        expiry=mocker.ANY,
+        version_id=DEFAULT_VERSION_ID,
+    )
+
+
 def test_cp_file(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR
@@ -1364,6 +1456,32 @@ def test_cp_file(storage):
     assert "homedir/enddir/test_file.txt" in files
 
     fs.rm("homedir", recursive=True)
+
+
+async def test_cp_file_versioned(storage, mocker):
+    from azure.storage.blob.aio import BlobClient
+
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        version_aware=True,
+        skip_instance_cache=True,
+    )
+    fs.mkdir("homedir")
+    fs.mkdir("homedir/enddir")
+    fs.touch("homedir/startdir/test_file.txt")
+    start_copy_from_url = mocker.patch.object(BlobClient, "start_copy_from_url")
+
+    try:
+        await fs._cp_file(
+            f"homedir/startdir/test_file.txt?versionid={DEFAULT_VERSION_ID}",
+            "homedir/enddir/test_file.txt",
+        )
+        start_copy_from_url.assert_called_once()
+        url = start_copy_from_url.call_args.args[0]
+        assert url.endswith(f"?versionid={DEFAULT_VERSION_ID}")
+    finally:
+        fs.rm("homedir", recursive=True)
 
 
 def test_exists(storage):
@@ -1398,6 +1516,26 @@ def test_exists_directory(storage):
     assert fs.exists("temp-exists")
 
 
+async def test_exists_versioned(storage, mocker):
+    from azure.core.exceptions import HttpResponseError
+    from azure.storage.blob.aio import BlobClient
+
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        version_aware=True,
+        skip_instance_cache=True,
+    )
+    exists = mocker.patch.object(BlobClient, "exists")
+
+    await fs._exists(f"data/root/a/file.txt?versionid={DEFAULT_VERSION_ID}")
+    exists.assert_called_once_with(version_id=DEFAULT_VERSION_ID)
+
+    exists.reset_mock()
+    exists.side_effect = HttpResponseError
+    assert not await fs._exists("data/root/a/file.txt?versionid=invalid_version")
+
+
 def test_find_with_prefix(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR
@@ -1424,3 +1562,98 @@ def test_find_with_prefix(storage):
     assert test_1s == [test_bucket_name + "/prefixes/test_1"] + [
         test_bucket_name + f"/prefixes/test_{cursor}" for cursor in range(10, 20)
     ]
+
+
+@pytest.mark.parametrize("proto", [None, "abfs://", "az://"])
+@pytest.mark.parametrize("path", ["container/file", "container/file?versionid=1234"])
+def test_strip_protocol(proto, path):
+    assert (
+        AzureBlobFileSystem._strip_protocol(f"{proto}{path}" if proto else path) == path
+    )
+
+
+@pytest.mark.parametrize("proto", ["", "abfs://", "az://"])
+@pytest.mark.parametrize("key", ["file", "dir/file"])
+@pytest.mark.parametrize("version_aware", [True, False])
+@pytest.mark.parametrize("version_id", [None, "1970-01-01T00:00:00.0000000Z"])
+def test_split_path(storage, proto, key, version_aware, version_id):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        version_aware=version_aware,
+        skip_instance_cache=True,
+    )
+    path = "".join(
+        [proto, "container/", key, f"?versionid={version_id}" if version_id else ""]
+    )
+    assert fs.split_path(path) == (
+        "container",
+        key,
+        version_id if version_aware else None,
+    )
+
+
+async def test_details_versioned(storage):
+    from azure.storage.blob import BlobProperties
+
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        version_aware=True,
+        skip_instance_cache=True,
+    )
+
+    path = "root/a/file.txt"
+
+    blob_unversioned = BlobProperties(name=path)
+
+    blob_latest = BlobProperties(name=path)
+    blob_latest["version_id"] = LATEST_VERSION_ID
+    blob_latest["is_current_version"] = True
+
+    blob_previous = BlobProperties(name=path)
+    blob_previous["version_id"] = DEFAULT_VERSION_ID
+    blob_previous["is_current_version"] = None
+
+    await fs._details(
+        [blob_unversioned, blob_latest, blob_previous],
+        target_path=path,
+        version_id=None,
+    ) == [blob_unversioned, blob_latest]
+    await fs._details(
+        [blob_unversioned, blob_latest, blob_previous],
+        target_path=path,
+        version_id=DEFAULT_VERSION_ID,
+    ) == [blob_previous]
+    await fs._details(
+        [blob_unversioned, blob_latest, blob_previous],
+        target_path=path,
+        version_id=LATEST_VERSION_ID,
+    ) == [blob_latest]
+
+
+async def test_get_file_versioned(storage, mocker):
+    from azure.core.exceptions import ResourceNotFoundError
+    from azure.storage.blob.aio import BlobClient
+
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        version_aware=True,
+        skip_instance_cache=True,
+    )
+    download_blob = mocker.patch.object(BlobClient, "download_blob")
+
+    with tempfile.TemporaryDirectory() as td:
+        local_file = os.path.join(td, "file.txt")
+        await fs._get_file(
+            f"data/root/a/file.txt?versionid={DEFAULT_VERSION_ID}", local_file
+        )
+        download_blob.assert_called_once_with(
+            raw_response_hook=mocker.ANY, version_id=DEFAULT_VERSION_ID
+        )
+
+    download_blob.reset_mock()
+    download_blob.side_effect = ResourceNotFoundError
+    with pytest.raises(FileNotFoundError):
+        await fs._get_file("data/root/a/file.txt?versionid=invalid_version", "file.txt")

--- a/adlfs/utils.py
+++ b/adlfs/utils.py
@@ -2,9 +2,11 @@ from typing import Optional
 
 
 def match_blob_version(blob, version_id: Optional[str]):
+    blob_version_id = blob.get("version_id")
     return (
-        version_id is None and ("version_id" not in blob or blob["is_current_version"])
-    ) or (version_id is not None and blob["version_id"] == version_id)
+        version_id is None
+        and (blob_version_id is None or blob.get("is_current_version"))
+    ) or blob_version_id == version_id
 
 
 async def filter_blobs(

--- a/adlfs/utils.py
+++ b/adlfs/utils.py
@@ -68,4 +68,5 @@ async def close_credential(file_obj):
     Implements asynchronous closure of credentials for
     AzureBlobFile objects
     """
-    await file_obj.credential.close()
+    if file_obj.credential is not None:
+        await file_obj.credential.close()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "azure-core>=1.7.0",
         "azure-datalake-store>=0.0.46,<0.1",
         "azure-identity",
-        "azure-storage-blob>=12.5.0",
+        "azure-storage-blob>=12.12.0",
         "fsspec>=2021.10.1",
     ],
     extras_require={


### PR DESCRIPTION
Implements `AzureBlobFileSystem` support for [blob versioning](https://docs.microsoft.com/en-us/azure/storage/blobs/versioning-overview) equivalent to what is currently supported in s3fs

- Filesystem must be configured with `version_aware=True` (and container must have versioning enabled)
- `version_id` property returned in fs read methods that return file details (i.e. `find`, `ls`, `info`)
    - Defaults to `None` when filesystem or container is not versioning-aware
- For file read methods specific blob version ID can be specified via `version_id` kwarg or via the requested path using `versionid` query parameter
    - path example: `abfs://my_container/path/to/versioned_file?versionid=some_version_id`
    - `versionid` used in path instead of `version_id` so paths are consistent with the Azure REST API [URI format](https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob#uri-parameters). This is consistent with the s3fs implementation which uses `version_id` in the fsspec python API and `VersionId` in paths (to match the AWS URI format)

Regarding testing:
- Version-aware filesystem methods have been manually tested against actual Azure containers with versioning enabled
- Azurite does not support blob versioning (it will ignore any versioning related API arguments)
- Version-aware filesystem methods are currently tested with mocked Azure SDK calls to ensure that we at least make calls with the correct arguments, and can parse/filter any returned version-aware blob properties

~~TODO:~~
- [x] figure out easiest test implementation (azurite does not currently implement any of the blob versioning functionality: https://github.com/Azure/Azurite/issues/665)