### PR TITLE
_strip_protocol: handle lists

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -483,6 +483,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
         str
             Returns a path without the protocol
         """
+        if isinstance(path, list):
+            return [cls._strip_protocol(p) for p in path]
+
         STORE_SUFFIX = ".dfs.core.windows.net"
         logger.debug(f"_strip_protocol for {path}")
         if not path.startswith(("abfs://", "az://", "abfss://")):


### PR DESCRIPTION
Triggerred when trying to fs.get a directory

```
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/dvc_objects/fs/base.py:485: in get
    return self.fs.get(
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/fsspec/asyn.py:111: in wrapper
    return sync(self.loop, func, *args, **kwargs)
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/fsspec/asyn.py:96: in sync
    raise return_result
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/fsspec/asyn.py:53: in _runner
    result[0] = await coro
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/fsspec/asyn.py:534: in _get
    rpath = self._strip_protocol(rpath)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cls = <class 'adlfs.spec.AzureBlobFileSystem'>
path = ['tests/60b4727b-41cd-4070-a048-1ece6aa81579/dir/file', 'tests/60b4727b-41cd-4070-a048-1ece6aa81579/dir/subdir/subfile']

    @classmethod
    def _strip_protocol(cls, path: str):
        """
        Remove the protocol from the input path

        Parameters
        ----------
        path: str
            Path to remove the protocol from

        Returns
        -------
        str
            Returns a path without the protocol
        """
        STORE_SUFFIX = ".dfs.core.windows.net"
        logger.debug(f"_strip_protocol for {path}")
>       if not path.startswith(("abfs://", "az://", "abfss://")):
E       AttributeError: 'list' object has no attribute 'startswith'
```

We do a similar thing in gcsfs https://github.com/fsspec/gcsfs/blob/1523233866ab6ae0321e7f9f3a0a6061449682bf/gcsfs/core.py#L324