### PR TITLE
Update setup.py to include aiohttp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "azure-identity",
         "azure-storage-blob>=12.12.0",
         "fsspec>=2021.10.1",
+        "aiohttp>=3.3.0",
     ],
     extras_require={
         "docs": ["sphinx", "myst-parser", "furo", "numpydoc"],

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "azure-identity",
         "azure-storage-blob>=12.12.0",
         "fsspec>=2021.10.1",
-        "aiohttp>=3.3.0",
+        "aiohttp>=3.7.0",
     ],
     extras_require={
         "docs": ["sphinx", "myst-parser", "furo", "numpydoc"],


### PR DESCRIPTION
aiohttp added to requirements, related to issue 343 (https://github.com/fsspec/adlfs/issues/343)

This is a simple fix, and might not be the right approach but currently:

- The latest version of adlfs fails if aiohttp not installed, and doesn't install adlfs thorough pip (looking at the git blame, I think it may be a problem on the end of azure-storage, so could just be a problem exposed from there)

This pull request:

- Adds on aiohttp to the requirements