### PR TITLE
Respect onerror='return' in AzureBlobFileSystem.cat

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1671,16 +1671,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
             url = f"{bc.url}?{sas_token}"
         return url
 
-    def expand_path(
-        self, path, recursive=False, maxdepth=None, skip_noexist=True
-    ):
+    def expand_path(self, path, recursive=False, maxdepth=None, skip_noexist=True):
         return sync(
-            self.loop,
-            self._expand_path,
-            path,
-            recursive,
-            maxdepth,
-            skip_noexist
+            self.loop, self._expand_path, path, recursive, maxdepth, skip_noexist
         )
 
     async def _expand_path(


### PR DESCRIPTION
supersedes #350 
closes #358 

This commits adds an option to keep paths in the output set of AzureBlobFileSystem._expand_path even when the blob doesn't exist.

This change is motivated by the onerror='return' option in cat, one of the callers of _expand_path (or expand_path). The stripping of none-existing paths undermines the onerror='return' and onerror='omit' in cat.