### PR TITLE
Reimplement fs.info() to not depend on fs.ls()

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -745,12 +745,6 @@ class AzureBlobFileSystem(AsyncFileSystem):
                 )
                 if return_glob:
                     return finalblobs
-                finalblobs = await self._details(
-                    outblobs,
-                    target_path=target_path,
-                    version_id=version_id,
-                    versions=versions,
-                )
                 if not finalblobs:
                     if not await self._exists(target_path):
                         raise FileNotFoundError

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -686,72 +686,67 @@ class AzureBlobFileSystem(AsyncFileSystem):
                 match_blob_version(b, version_id) for b in self.dircache[target_path]
             )
         ):
-            if container not in ["", delimiter]:
-                # This is the case where the container name is passed
-                async with self.service_client.get_container_client(
-                    container=container
-                ) as cc:
-                    path = path.strip("/")
-                    include = ["metadata"]
-                    if version_id is not None or versions:
-                        assert self.version_aware
-                        include.append("versions")
-                    blobs = cc.walk_blobs(include=include, name_starts_with=path)
+            assert container not in ["", delimiter]
+            async with self.service_client.get_container_client(
+                container=container
+            ) as cc:
+                path = path.strip("/")
+                include = ["metadata"]
+                if version_id is not None or versions:
+                    assert self.version_aware
+                    include.append("versions")
+                blobs = cc.walk_blobs(include=include, name_starts_with=path)
 
-                # Check the depth that needs to be screened
-                depth = target_path.count("/")
-                outblobs = []
-                try:
-                    async for next_blob in blobs:
-                        if depth in [0, 1] and path == "":
+            # Check the depth that needs to be screened
+            depth = target_path.count("/")
+            outblobs = []
+            try:
+                async for next_blob in blobs:
+                    if depth in [0, 1] and path == "":
+                        outblobs.append(next_blob)
+                    elif isinstance(next_blob, BlobProperties):
+                        if next_blob["name"].count("/") == depth:
                             outblobs.append(next_blob)
-                        elif isinstance(next_blob, BlobProperties):
-                            if next_blob["name"].count("/") == depth:
-                                outblobs.append(next_blob)
-                            elif not next_blob["name"].endswith("/") and (
-                                next_blob["name"].count("/") == (depth - 1)
+                        elif not next_blob["name"].endswith("/") and (
+                            next_blob["name"].count("/") == (depth - 1)
+                        ):
+                            outblobs.append(next_blob)
+                    else:
+                        async for blob_ in next_blob:
+                            if isinstance(blob_, BlobProperties) or isinstance(
+                                blob_, BlobPrefix
                             ):
-                                outblobs.append(next_blob)
-                        else:
-                            async for blob_ in next_blob:
-                                if isinstance(blob_, BlobProperties) or isinstance(
-                                    blob_, BlobPrefix
-                                ):
-                                    if blob_["name"].endswith("/"):
-                                        if (
-                                            blob_["name"].rstrip("/").count("/")
-                                            == depth
-                                        ):
-                                            outblobs.append(blob_)
-                                        elif blob_["name"].count("/") == depth and (
-                                            hasattr(blob_, "size")
-                                            and blob_["size"] == 0
-                                        ):
-                                            outblobs.append(blob_)
-                                        else:
-                                            pass
-                                    elif blob_["name"].count("/") == (depth):
+                                if blob_["name"].endswith("/"):
+                                    if blob_["name"].rstrip("/").count("/") == depth:
+                                        outblobs.append(blob_)
+                                    elif blob_["name"].count("/") == depth and (
+                                        hasattr(blob_, "size") and blob_["size"] == 0
+                                    ):
                                         outblobs.append(blob_)
                                     else:
                                         pass
-                except ResourceNotFoundError:
-                    raise FileNotFoundError
-                finalblobs = await self._details(
-                    outblobs,
-                    target_path=target_path,
-                    return_glob=return_glob,
-                    version_id=version_id,
-                    versions=versions,
-                )
-                if return_glob:
-                    return finalblobs
-                if not finalblobs:
-                    if not await self._exists(target_path):
-                        raise FileNotFoundError
-                    return []
-                if not self.version_aware or finalblobs[0].get("is_current_version"):
-                    self.dircache[target_path] = finalblobs
+                                elif blob_["name"].count("/") == (depth):
+                                    outblobs.append(blob_)
+                                else:
+                                    pass
+            except ResourceNotFoundError:
+                raise FileNotFoundError
+            finalblobs = await self._details(
+                outblobs,
+                target_path=target_path,
+                return_glob=return_glob,
+                version_id=version_id,
+                versions=versions,
+            )
+            if return_glob:
                 return finalblobs
+            if not finalblobs:
+                if not await self._exists(target_path):
+                    raise FileNotFoundError
+                return []
+            if not self.version_aware or finalblobs[0].get("is_current_version"):
+                self.dircache[target_path] = finalblobs
+            return finalblobs
 
         return self.dircache[target_path]
 

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -880,41 +880,29 @@ class AzureBlobFileSystem(AsyncFileSystem):
                 fname = f"{content.container}{delimiter}{content.name}"
                 fname = fname.rstrip(delimiter)
                 if content.has_key("size"):  # NOQA
-                    data.update({"name": fname})
-                    data.update({"size": content.size})
-                    data.update({"type": "file"})
+                    data["name"] = fname
+                    data["size"] = content.size
+                    data["type"] = "file"
                 else:
-                    data.update({"name": fname})
-                    data.update({"size": None})
-                    data.update({"type": "directory"})
+                    data["name"] = fname
+                    data["size"] = None
+                    data["type"] = "directory"
             else:
                 fname = f"{content.name}"
-                data.update({"name": fname})
-                data.update({"size": None})
-                data.update({"type": "directory"})
-            if "metadata" in data.keys():
-                if data["metadata"] is not None:
-                    if (
-                        "is_directory" in data["metadata"].keys()
-                        and data["metadata"]["is_directory"] == "true"
-                    ):
-                        data.update({"type": "directory"})
-                        data.update({"size": None})
-                    elif (
-                        "is_directory" in data["metadata"].keys()
-                        and data["metadata"]["is_directory"] == "false"
-                    ):
-                        data.update({"type": "file"})
-                    elif (
-                        "hdi_isfolder" in data["metadata"].keys()
-                        and data["metadata"]["hdi_isfolder"] == "true"
-                    ):
-                        data.update({"type": "directory"})
-                        data.update({"size": None})
-                    else:
-                        pass
+                data["name"] = fname
+                data["size"] = None
+                data["type"] = "directory"
+            if data.get("metadata"):
+                if data["metadata"].get("is_directory") == "true":
+                    data["type"] = "directory"
+                    data["size"] = None
+                elif data["metadata"].get("is_directory") == "false":
+                    data["type"] = "file"
+                elif data["metadata"].get("hdi_isfolder") == "true":
+                    data["type"] = "directory"
+                    data["size"] = None
             if return_glob:
-                data.update({"name": data["name"].rstrip("/")})
+                data["name"] = data["name"].rstrip("/")
             output.append(data)
         if target_path:
             if (

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -378,6 +378,23 @@ def test_info(storage):
     )
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "does-not-exist",
+        "does-not-exist/foo",
+        "data/does_not_exist",
+        "data/root/does_not_exist",
+    ],
+)
+def test_info_missing(storage, path):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    with pytest.raises(FileNotFoundError):
+        fs.info(path)
+
+
 def test_time_info(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -30,6 +30,7 @@ def test_connect(storage):
 def assert_blob_equals(blob, expected_blob):
     irregular_props = [
         "etag",
+        "deleted",
     ]
 
     time_based_props = [
@@ -132,7 +133,6 @@ def test_ls(storage):
                 "size": 10,
                 "type": "file",
                 "archive_status": None,
-                "deleted": None,
                 "creation_time": storage.insert_time,
                 "last_modified": storage.insert_time,
                 "deleted_time": None,
@@ -164,7 +164,6 @@ def test_ls(storage):
                 "size": 10,
                 "type": "file",
                 "archive_status": None,
-                "deleted": None,
                 "creation_time": storage.insert_time,
                 "last_modified": storage.insert_time,
                 "deleted_time": None,
@@ -189,7 +188,6 @@ def test_ls(storage):
                 "size": 10,
                 "type": "file",
                 "archive_status": None,
-                "deleted": None,
                 "creation_time": storage.insert_time,
                 "last_modified": storage.insert_time,
                 "deleted_time": None,
@@ -221,7 +219,6 @@ def test_ls(storage):
                 "size": 10,
                 "type": "file",
                 "archive_status": None,
-                "deleted": None,
                 "creation_time": storage.insert_time,
                 "last_modified": storage.insert_time,
                 "deleted_time": None,
@@ -290,9 +287,13 @@ async def test_ls_versioned(storage, mocker):
     )
 
 
-def test_info(storage):
+@pytest.mark.parametrize("version_aware", [False, True])
+def test_info(storage, version_aware):
     fs = AzureBlobFileSystem(
-        account_name=storage.account_name, connection_string=CONN_STR
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        version_aware=version_aware,
+        skip_instance_cache=True,
     )
 
     container_info = fs.info("data")
@@ -302,7 +303,6 @@ def test_info(storage):
             "name": "data",
             "type": "directory",
             "size": None,
-            "deleted": None,
             "last_modified": storage.insert_time,
             "metadata": None,
         },
@@ -319,63 +319,58 @@ def test_info(storage):
     )
 
     file_info = fs.info("data/root/a/file.txt")
-    assert_blob_equals(
-        file_info,
-        {
-            "name": "data/root/a/file.txt",
-            "size": 10,
-            "type": "file",
-            "archive_status": None,
-            "deleted": None,
-            "creation_time": storage.insert_time,
-            "last_modified": storage.insert_time,
-            "deleted_time": None,
-            "last_accessed_on": None,
-            "remaining_retention_days": None,
-            "tag_count": None,
-            "tags": None,
-            "metadata": {},
-            "content_settings": {
-                "content_type": "application/octet-stream",
-                "content_encoding": None,
-                "content_language": None,
-                "content_md5": bytearray(
-                    b"x\x1e^$]i\xb5f\x97\x9b\x86\xe2\x8d#\xf2\xc7"
-                ),
-                "content_disposition": None,
-                "cache_control": None,
-            },
+    expected = {
+        "name": "data/root/a/file.txt",
+        "size": 10,
+        "type": "file",
+        "archive_status": None,
+        "creation_time": storage.insert_time,
+        "last_modified": storage.insert_time,
+        "deleted_time": None,
+        "last_accessed_on": None,
+        "remaining_retention_days": None,
+        "tag_count": None,
+        "tags": None,
+        "metadata": {},
+        "content_settings": {
+            "content_type": "application/octet-stream",
+            "content_encoding": None,
+            "content_language": None,
+            "content_md5": bytearray(b"x\x1e^$]i\xb5f\x97\x9b\x86\xe2\x8d#\xf2\xc7"),
+            "content_disposition": None,
+            "cache_control": None,
         },
-    )
+    }
+    if version_aware:
+        expected.update({"is_current_version": None, "version_id": None})
+    assert_blob_equals(file_info, expected)
+
     file_with_meta_info = fs.info("data/root/d/file_with_metadata.txt")
-    assert_blob_equals(
-        file_with_meta_info,
-        {
-            "name": "data/root/d/file_with_metadata.txt",
-            "size": 10,
-            "type": "file",
-            "archive_status": None,
-            "deleted": None,
-            "creation_time": storage.insert_time,
-            "last_modified": storage.insert_time,
-            "deleted_time": None,
-            "last_accessed_on": None,
-            "remaining_retention_days": None,
-            "tag_count": None,
-            "tags": None,
-            "metadata": {"meta": "data"},
-            "content_settings": {
-                "content_type": "application/octet-stream",
-                "content_encoding": None,
-                "content_language": None,
-                "content_md5": bytearray(
-                    b"x\x1e^$]i\xb5f\x97\x9b\x86\xe2\x8d#\xf2\xc7"
-                ),
-                "content_disposition": None,
-                "cache_control": None,
-            },
+    expected = {
+        "name": "data/root/d/file_with_metadata.txt",
+        "size": 10,
+        "type": "file",
+        "archive_status": None,
+        "creation_time": storage.insert_time,
+        "last_modified": storage.insert_time,
+        "deleted_time": None,
+        "last_accessed_on": None,
+        "remaining_retention_days": None,
+        "tag_count": None,
+        "tags": None,
+        "metadata": {"meta": "data"},
+        "content_settings": {
+            "content_type": "application/octet-stream",
+            "content_encoding": None,
+            "content_language": None,
+            "content_md5": bytearray(b"x\x1e^$]i\xb5f\x97\x9b\x86\xe2\x8d#\xf2\xc7"),
+            "content_disposition": None,
+            "cache_control": None,
         },
-    )
+    }
+    if version_aware:
+        expected.update({"is_current_version": None, "version_id": None})
+    assert_blob_equals(file_with_meta_info, expected)
 
 
 @pytest.mark.parametrize(
@@ -511,7 +506,6 @@ def test_find(storage):
                 "size": 10,
                 "type": "file",
                 "archive_status": None,
-                "deleted": None,
                 "creation_time": storage.insert_time,
                 "last_modified": storage.insert_time,
                 "deleted_time": None,
@@ -1577,6 +1571,7 @@ def test_exists(storage):
     assert fs.exists("data/")
     assert not fs.exists("non-existent-container")
     assert not fs.exists("non-existent-container/")
+    assert not fs.exists("non-existent-container/key")
     assert fs.exists("")
     assert not fs.exists("data/not-a-key")
 


### PR DESCRIPTION
`fs.info()` now only queries the properties of its argument, instead of potentially doing a full listing of the parent directory, which should improve its performance in many cases.

Fixes #377 and #380.

Note: this PR contains refactorings of related methods that I ended up not modifying otherwise, I could split them off if that makes reviewing easier.

