### PR TITLE
Fix missing kwargs injection on upload blob call

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
       language_version: python3

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1413,7 +1413,10 @@ class AzureBlobFileSystem(AsyncFileSystem):
             container=container_name, blob=path
         ) as bc:
             result = await bc.upload_blob(
-                data=value, overwrite=overwrite, metadata={"is_directory": "false"}
+                data=value,
+                overwrite=overwrite,
+                metadata={"is_directory": "false"},
+                **kwargs,
             )
         self.invalidate_cache(self._parent(path))
         return result

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,14 @@ to list all the files or directories in the top-level of a storage container, yo
 api.md
 ```
 
+**Note**: When uploading a blob (with `write_bytes` or `write_text`) you can injects kwargs directly into `upload_blob` method:
+
+```{code-block} python
+>>> from azure.storage.blob import ContentSettings
+>>> fs = adlfs.AzureBlobFileSystem(account_name="ai4edataeuwest")
+>>> fs.write_bytes(path="path", value=data, overwrite=True, **{"content_settings": ContentSettings(content_type="application/json", content_encoding="br")})
+```
+
 [fsspec]: https://filesystem-spec.readthedocs.io
 [Azure Blob storage]: https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction
 [Azure Data Lake Storage Gen2]: https://docs.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction


### PR DESCRIPTION
Hello there.

Currently, when uploading a blob, there's no way of injecting other arguments besides the `data`, `overwrite`, and `metadata`.

An example would be when I want to compress data and set the content encoding of the data to `br`. For that I need to pass a `ContentSettings` object into the `upload_blob` method kwargs:

i.e:
```python

from azure.storage.blob import ContentSettings
import brotli
import fsspec

CONN_STRING = "<CONN_STRING>"
CONTAINER = "kwargs-injection"

abfs = fsspec.filesystem(
    "abfs",
    connection_string=CONN_STRING,
)

if __name__ == "__main__":
    content_settings = ContentSettings(
        content_type="application/json",
        content_encoding="br",
    )
    abfs.mkdir(CONTAINER, exist_ok=True)
    abfs.write_bytes(
        path=f"{CONTAINER}/compressed.br",
        value=brotli.compress(b'{"a": "hello world"}', quality=1),
        overwrite=True,
        **{"content_settings": content_settings},
    )

```

What I'm expecting to see in the azure storage containers web interface, when consulting the blob properties:
[](url)
![Screenshot 2023-01-26 at 11 22 36](https://user-images.githubusercontent.com/893601/214837287-517016ed-93cf-4bc9-94d6-1040e75270d0.png)

What I see instead (no content encoding defined):
![Screenshot 2023-01-26 at 11 35 05](https://user-images.githubusercontent.com/893601/214837291-9e707a60-2ef7-400c-af0c-3c8fc6df319c.png)


script requirements:
`$ pip install fsspec adlfs brotli`