### PR TITLE
Fix recursive upload with directory path

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1587,7 +1587,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         container_name, path, _ = self.split_path(rpath, delimiter=delimiter)
 
         if os.path.isdir(lpath):
-            return
+            await self._mkdir(rpath)
         else:
             try:
                 with open(lpath, "rb") as f1:

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1587,7 +1587,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         container_name, path, _ = self.split_path(rpath, delimiter=delimiter)
 
         if os.path.isdir(lpath):
-            self.makedirs(rpath, exist_ok=True)
+            return
         else:
             try:
                 with open(lpath, "rb") as f1:


### PR DESCRIPTION
When uploading a directory recursively, the function call hangs forever if it is a directory path. 

It seems there is an issue with async calls but unfortunately I dont know what is it exactly. As the function is inherited from [fsspec](https://github.com/fsspec/filesystem_spec/blob/4143dc16bea64a59efd1ee18ad2b4e560a9b2011/fsspec/spec.py#L288) and it is a noop function, I expect it to return immediately but that is not the case. So, this should fix the issue by immediately returning the function.