### PR TITLE
gha: docs: don't use ammaraskar/sphinx-action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,14 +12,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - run: python -m pip install -e .[docs]
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: "docs/"
+
+    - name: Build
+      run: |
+        python -m pip install -e .[docs]
+        sphinx-build docs dist/site -b dirhtml -a
+
     - name: Publish
       if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_build/html
+        publish_dir: dist/site
 


### PR DESCRIPTION
Something about it is broken, the repository seems dead and we don't even
need it anyway. So just dropping it and fixing the ci.
