### PR TITLE
Passing the error message along with FileNotFoundError

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -570,9 +570,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
             if await self._dir_exists(container, path):
                 return {"name": fullpath, "size": None, "type": "directory"}
 
-        raise FileNotFoundError(
-            errno.ENOENT, os.strerror(errno.ENOENT), fullpath
-        )
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), fullpath)
 
     def glob(self, path, **kwargs):
         return sync(self.loop, self._glob, path)
@@ -1576,9 +1574,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                     out.add(fullpath)
 
         if not out:
-            raise FileNotFoundError(
-                errno.ENOENT, os.strerror(errno.ENOENT), path
-            )
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
         return list(sorted(out))
 
     async def _put_file(

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -571,7 +571,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                 return {"name": fullpath, "size": None, "type": "directory"}
 
         raise FileNotFoundError(
-            errno.ENOENT, os.strerror(errno.ENOENT), target_path
+            errno.ENOENT, os.strerror(errno.ENOENT), fullpath
         )
 
     def glob(self, path, **kwargs):

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -570,7 +570,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
             if await self._dir_exists(container, path):
                 return {"name": fullpath, "size": None, "type": "directory"}
 
-        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), fullpath)
+        raise FileNotFoundError(
+            errno.ENOENT, os.strerror(errno.ENOENT), target_path
+        )
 
     def glob(self, path, **kwargs):
         return sync(self.loop, self._glob, path)
@@ -732,7 +734,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
                             else:
                                 pass
         except ResourceNotFoundError:
-            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), target_path)
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), target_path
+            )
         finalblobs = await self._details(
             outblobs,
             target_path=target_path,
@@ -744,7 +748,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
             return finalblobs
         if not finalblobs:
             if not await self._exists(target_path):
-                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), target_path)
+                raise FileNotFoundError(
+                    errno.ENOENT, os.strerror(errno.ENOENT), target_path
+                )
             return []
         if not self.version_aware or finalblobs[0].get("is_current_version"):
             self.dircache[target_path] = finalblobs
@@ -1570,7 +1576,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
                     out.add(fullpath)
 
         if not out:
-            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), path
+            )
         return list(sorted(out))
 
     async def _put_file(

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function
 
 import asyncio
+import errno
 import io
 import logging
 import os
@@ -569,7 +570,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
             if await self._dir_exists(container, path):
                 return {"name": fullpath, "size": None, "type": "directory"}
 
-        raise FileNotFoundError
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), fullpath)
 
     def glob(self, path, **kwargs):
         return sync(self.loop, self._glob, path)
@@ -731,7 +732,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                             else:
                                 pass
         except ResourceNotFoundError:
-            raise FileNotFoundError
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), target_path)
         finalblobs = await self._details(
             outblobs,
             target_path=target_path,
@@ -743,7 +744,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
             return finalblobs
         if not finalblobs:
             if not await self._exists(target_path):
-                raise FileNotFoundError
+                raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), target_path)
             return []
         if not self.version_aware or finalblobs[0].get("is_current_version"):
             self.dircache[target_path] = finalblobs
@@ -1569,7 +1570,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                     out.add(fullpath)
 
         if not out:
-            raise FileNotFoundError
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
         return list(sorted(out))
 
     async def _put_file(


### PR DESCRIPTION
If the file is not found, currently adlfs just throws the FileNotFoundError without an error message or the path which is not found.
Having an error message and file path in the error helps in improving the readability of the error.

So in this PR, just updated the spec file to pass the path and message along with the error.