### PR TITLE
put_file: default to overwrite=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 ----------
 
 - Handle mixed casing for `hdi_isfolder` metadata when determining whether a blob should be treated as a folder.
+- `_put_file`: `overwrite` now defaults to `True`.
 
 2023.10.0
 ---------

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1548,10 +1548,10 @@ class AzureBlobFileSystem(AsyncFileSystem):
         lpath,
         rpath,
         delimiter="/",
-        overwrite=False,
+        overwrite=True,
         callback=None,
         max_concurrency=None,
-        **kwargws,
+        **kwargs,
     ):
         """
         Copy single file to remote
@@ -1559,7 +1559,8 @@ class AzureBlobFileSystem(AsyncFileSystem):
         :param lpath: Path to local file
         :param rpath: Path to remote file
         :param delimitier: Filepath delimiter
-        :param overwrite: Boolean (False).  If True, overwrite the existing file present
+        :param overwrite: Boolean (True). Whether to overwrite any existing file
+            (True) or raise if one already exists (False).
         """
 
         container_name, path, _ = self.split_path(rpath, delimiter=delimiter)

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1854,7 +1854,7 @@ async def test_put_file_timeout(storage, mocker, tmp_path):
     upload_blob.assert_called_once_with(
         mocker.ANY,
         metadata={"is_directory": "false"},
-        overwrite=False,
+        overwrite=True,
         raw_response_hook=None,
         max_concurrency=fs.max_concurrency,
         timeout=11,


### PR DESCRIPTION
adlfs `put_file()` currently raises `FileExistsError` by default if the specified blob already exists. In version aware contexts `put_file` should default to succeeding even if the specified blob already exists, so that put_file creates a new version of the blob.

---

I should also note that as far as I can tell every other fsspec `put_file` implementation defaults to overwriting an existing file, so I'm also wondering whether the current adlfs `overwrite=False` default should be changed in all contexts (regardless of whether or not the fs is version aware)?