### PR TITLE
azure sdk_moniker kwarg bug (downstream from azure-storage-blob)

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -219,7 +219,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         sas_token: str = None,
         request_session=None,
         socket_timeout=_SOCKET_TIMEOUT_DEFAULT,
-        blocksize: int = create_configuration(storage_sdk="blob").max_block_size,
+        blocksize: int = create_configuration(storage_sdk="blob", sdk_moniker="storage-blob").max_block_size,
         client_id: str = None,
         client_secret: str = None,
         tenant_id: str = None,

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -219,7 +219,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
         sas_token: str = None,
         request_session=None,
         socket_timeout=_SOCKET_TIMEOUT_DEFAULT,
-        blocksize: int = create_configuration(storage_sdk="blob", sdk_moniker="storage-blob").max_block_size,
+        blocksize: int = create_configuration(
+            storage_sdk="blob", sdk_moniker="storage-blob"
+        ).max_block_size,
         client_id: str = None,
         client_secret: str = None,
         tenant_id: str = None,
@@ -285,7 +287,6 @@ class AzureBlobFileSystem(AsyncFileSystem):
             and self.sas_token is None
             and self.account_key is None
         ):
-
             (
                 self.credential,
                 self.sync_credential,
@@ -397,7 +398,6 @@ class AzureBlobFileSystem(AsyncFileSystem):
         return (async_credential, sync_credential)
 
     def _get_default_azure_credential(self, **kwargs):
-
         """
         Create a Credential for authentication using DefaultAzureCredential
 


### PR DESCRIPTION
Not sure if this is the appropriate fix or not? This PR would introduce compatibilty with azure-storage-blob version 12.18.0 which now requires sdk_moniker as a keyword argument.

For further details, [see issue 424](https://github.com/fsspec/adlfs/issues/424)