### PR TITLE
Avoid use of private APIs from azure.storage

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -23,12 +23,12 @@ from azure.core.exceptions import (
 )
 from azure.storage.blob import (
     BlobBlock,
-    BlobPrefix,
     BlobProperties,
     BlobSasPermissions,
     BlobType,
     generate_blob_sas,
 )
+from azure.storage.blob.aio import BlobPrefix
 from azure.storage.blob.aio import BlobServiceClient as AIOBlobServiceClient
 from fsspec.asyn import AsyncFileSystem, _get_batch_size, get_loop, sync, sync_wrapper
 from fsspec.spec import AbstractBufferedFile

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -21,11 +21,15 @@ from azure.core.exceptions import (
     ResourceExistsError,
     ResourceNotFoundError,
 )
-from azure.storage.blob import BlobSasPermissions, generate_blob_sas
-from azure.storage.blob._models import BlobBlock, BlobProperties, BlobType
-from azure.storage.blob._shared.base_client import create_configuration
+from azure.storage.blob import (
+    BlobBlock,
+    BlobPrefix,
+    BlobProperties,
+    BlobSasPermissions,
+    BlobType,
+    generate_blob_sas,
+)
 from azure.storage.blob.aio import BlobServiceClient as AIOBlobServiceClient
-from azure.storage.blob.aio._list_blobs_helper import BlobPrefix
 from fsspec.asyn import AsyncFileSystem, _get_batch_size, get_loop, sync, sync_wrapper
 from fsspec.spec import AbstractBufferedFile
 from fsspec.utils import infer_storage_options
@@ -61,6 +65,7 @@ VERSIONED_BLOB_PROPERTIES = [
     "is_current_version",
 ]
 _ROOT_PATH = "/"
+_DEFAULT_BLOCK_SIZE = 4 * 1024 * 1024
 
 _SOCKET_TIMEOUT_DEFAULT = object()
 
@@ -143,7 +148,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         The credentials with which to authenticate.  Optional if the account URL already has a SAS token.
         Can include an instance of TokenCredential class from azure.identity
     blocksize: int
-        The block size to use for download/upload operations. Defaults to the value of
+        The block size to use for download/upload operations. Defaults to hardcoded value of
         ``BlockBlobService.MAX_BLOCK_SIZE``
     client_id: str
         Client ID to use when authenticating using an AD Service Principal client/secret.
@@ -219,7 +224,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         sas_token: str = None,
         request_session=None,
         socket_timeout=_SOCKET_TIMEOUT_DEFAULT,
-        blocksize: int = create_configuration(storage_sdk="blob").max_block_size,
+        blocksize: int = _DEFAULT_BLOCK_SIZE
         client_id: str = None,
         client_secret: str = None,
         tenant_id: str = None,

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -224,7 +224,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         sas_token: str = None,
         request_session=None,
         socket_timeout=_SOCKET_TIMEOUT_DEFAULT,
-        blocksize: int = _DEFAULT_BLOCK_SIZE
+        blocksize: int = _DEFAULT_BLOCK_SIZE,
         client_id: str = None,
         client_secret: str = None,
         tenant_id: str = None,
@@ -290,7 +290,6 @@ class AzureBlobFileSystem(AsyncFileSystem):
             and self.sas_token is None
             and self.account_key is None
         ):
-
             (
                 self.credential,
                 self.sync_credential,
@@ -402,7 +401,6 @@ class AzureBlobFileSystem(AsyncFileSystem):
         return (async_credential, sync_credential)
 
     def _get_default_azure_credential(self, **kwargs):
-
         """
         Create a Credential for authentication using DefaultAzureCredential
 


### PR DESCRIPTION
This is designed to fix [issue 426](https://github.com/fsspec/adlfs/issues/426), and remove use of private modules from azure.storage - hopefully help avoid future issues like the recent [sdk_moniker key error](https://github.com/fsspec/adlfs/issues/424) cropping in.

There's two changes here, both of which are pretty minor, but the second of which might need some discussion on whether it's the right approach.

## Import switches

```BlobPrefix```, ```BlobBlock```, ```BlobPoperties``` and ```BlobType ```are all exposed as importables straight from azure.storage.blob without needing the private modules, so this is a drop in replacement.

## Default Block Size

This change might need a little more discussion - I've hardcoded it here to avoid using ```create_configuration```, which @jalauzon-msft suggested as a possibility, but that means it won't automatically change if azure shifts it in future.

The alternative approaches I can think of are:
- Continue using ```create_configuration```, which would be responsive to changes from azure, but also potentially lead to issues in future since it is a private method.
- Open an issue with azure SDK to add default block size as a supported importable constant (and either leave as is or hardcode in the meantime)
