### PR TITLE
callback: guard against invalid values

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -82,7 +82,9 @@ def make_callback(key, callback):
 
         current = response.context.get(key)
         total = response.context["data_stream_total"]
-        if not sent_total:
+        if current is None:
+            return
+        if not sent_total and total is not None:
             callback.set_size(total)
         callback.absolute_update(current)
 


### PR DESCRIPTION
See https://github.com/Azure/azure-sdk-for-python/issues/11419#issuecomment-628143480 on how to get progress information.
Also related: https://github.com/fsspec/adlfs/pull/275#issuecomment-1119411234 and https://github.com/iterative/dvc/issues/7704.

Invalid values should not be passed to callbacks.

cc @efiop 