### PR TITLE
tests: pin pytest-asyncio to 0.21.1

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ docker
 msrestazure
 pyarrow
 pytest
-pytest-asyncio
+pytest-asyncio==0.21.1
 pytest-cov
 pytest-mock
 requests


### PR DESCRIPTION
With newer versions we get a lot of errors like:

```
____________________________ test_isfile_versioned _____________________________

self = <Coroutine test_isfile_versioned>

    def runtest(self) -> None:
        self.obj = wrap_in_sync(
            # https://github.com/pytest-dev/pytest-asyncio/issues/596
            self.obj,  # type: ignore[has-type]
        )
>       super().runtest()

/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pytest_asyncio/plugin.py:431:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pytest_asyncio/plugin.py:879: in inner
    _loop.run_until_complete(task)
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/asyncio/base_events.py:592: in run_until_complete
    self._check_running()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <_UnixSelectorEventLoop running=True closed=False debug=False>

    def _check_running(self):
        if self.is_running():
>           raise RuntimeError('This event loop is already running')
E           RuntimeError: This event loop is already running

/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/asyncio/base_events.py:552: RuntimeError
```

Don't know precise reason and maybe using nest-asyncio package would fix that, but for now just pinning older version to move forward.