### PR TITLE
fs.url(): expose response content headers for pre-signed URLs

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1454,7 +1454,16 @@ class AzureBlobFileSystem(AsyncFileSystem):
     def url(self, path, expires=3600, **kwargs):
         return sync(self.loop, self._url, path, expires, **kwargs)
 
-    async def _url(self, path, expires=3600, **kwargs):
+    async def _url(
+        self,
+        path,
+        expires=3600,
+        content_disposition=None,
+        content_encoding=None,
+        content_language=None,
+        content_type=None,
+        **kwargs,
+    ):
         """Generate presigned URL to access path by HTTP
 
         Parameters
@@ -1463,6 +1472,14 @@ class AzureBlobFileSystem(AsyncFileSystem):
             the key path we are interested in
         expires : int
             the number of seconds this signature will be good for.
+        content_disposition : string
+            Response header value for Content-Disposition when this URL is accessed.
+        content_encoding: string
+            Response header value for Content-Encoding when this URL is accessed.
+        content_language: string
+            Response header value for Content-Language when this URL is accessed.
+        content_type: string
+            Response header value for Content-Type when this URL is accessed.
         """
         container_name, blob, version_id = self.split_path(path)
 
@@ -1474,6 +1491,10 @@ class AzureBlobFileSystem(AsyncFileSystem):
             permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(seconds=expires),
             version_id=version_id,
+            content_disposition=content_disposition,
+            content_encoding=content_encoding,
+            content_language=content_language,
+            content_type=content_type,
         )
 
         async with self.service_client.get_blob_client(container_name, blob) as bc:
@@ -1636,6 +1657,10 @@ class AzureBlobFileSystem(AsyncFileSystem):
     def download(self, rpath, lpath, recursive=False, **kwargs):
         """Alias of :ref:`FilesystemSpec.get`."""
         return self.get(rpath, lpath, recursive=recursive, **kwargs)
+
+    def sign(self, path, expiration=100, **kwargs):
+        """Create a signed URL representing the given path."""
+        return self.url(path, expires=expiration, **kwargs)
 
     async def _get_file(
         self,

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1538,6 +1538,10 @@ async def test_url_versioned(storage, mocker):
         permission=mocker.ANY,
         expiry=mocker.ANY,
         version_id=DEFAULT_VERSION_ID,
+        content_disposition=None,
+        content_encoding=None,
+        content_language=None,
+        content_type=None,
     )
 
 


### PR DESCRIPTION
Exposes the fields for setting Content-Disposition, Content-Type, Content-Encoding, Content-Language response headers on a pre-signed URL. This can be useful when the desired user-facing downloaded filename is not necessarily the same as the blob path name.