### PR TITLE
Revert #383

### DIFF
--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -739,42 +739,6 @@ def test_rm_recursive(storage):
         fs.ls("data/root/c")
 
 
-def test_rm_multiple_items(storage):
-    fs = AzureBlobFileSystem(
-        account_name=storage.account_name, connection_string=CONN_STR
-    )
-    for i in range(2):
-        fs.makedir(f"new-container{i}")
-        assert f"new-container{i}" in fs.ls("")
-
-        with fs.open(path=f"new-container{i}/file0.txt", mode="wb") as f:
-            f.write(b"0123456789")
-
-        with fs.open(f"new-container{i}/file1.txt", "wb") as f:
-            f.write(b"0123456789")
-
-        assert fs.ls(f"new-container{i}") == [
-            f"new-container{i}/file0.txt",
-            f"new-container{i}/file1.txt",
-        ]
-
-    fs.rm(
-        [
-            "new-container0/file0.txt",
-            "new-container0/file1.txt",
-            "new-container1/file0.txt",
-            "new-container1/file1.txt",
-        ],
-        recursive=True,
-    )
-
-    assert fs.ls("new-container0") == []
-    assert fs.ls("new-container1") == []
-
-    for i in range(2):
-        fs.rm(f"new-container{i}")
-
-
 def test_mkdir(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name,


### PR DESCRIPTION
Resolves https://github.com/fsspec/adlfs/issues/389

Unfortunately https://github.com/fsspec/adlfs/pull/383 broke recursive delete on blob storage accounts with hierarchical namespace enabled (ADLS gen2). 

```
azure.core.exceptions.ResourceExistsError: This operation is not permitted on a non-empty directory.
RequestId:f3042353-701e-0069-7a68-dc7b41000000
Time:2023-09-01T00:08:11.0327332Z
ErrorCode:DirectoryIsNotEmpty
Content: <?xml version="1.0" encoding="utf-8"?><Error><Code>DirectoryIsNotEmpty</Code><Message>This operation is not permitted on a non-empty directory.
RequestId:f3042353-701e-0069-7a68-dc7b41000000
Time:2023-09-01T00:08:11.0327332Z</Message></Error>
```

This is because https://github.com/fsspec/adlfs/pull/383 causes all blobs (including hierarchical namespace directory markers) do be deleted asynchronously. There is nothing to ensure that the contents of a directory are deleted before the directory itself, hence the error above. 

There are some proposals about how to fix this without reverting discussed on the issue https://github.com/fsspec/adlfs/issues/389#issuecomment-1845899468. However those will require some thinking and testing. If we want to fix it properly I think the best way would be to have separate code paths for hierarchical vs flat namespace but that would be significantly more complicated (see https://github.com/apache/arrow/blob/2e8bd8d0b53560a561656337021abc3e4aa73f8c/cpp/src/arrow/filesystem/azurefs.cc#L1822-L1848 for an example). I think its most important to just get back to a state where it works.  

I hope this doesn't come across as rude to revert someone else's contribution without their acknowledgement. I did [try to gain some consensus](https://github.com/fsspec/adlfs/issues/389#issuecomment-1866816269) and nobody responded for over a month. Being stuck on `2022.11.0` is causing us a lot of issues.