### PR TITLE
Fix recursive delete on hierarchical namespace accounts

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1210,7 +1210,8 @@ class AzureBlobFileSystem(AsyncFileSystem):
                     raise ex
 
             # Directory markers of non-empty directories must be deleted in reverse order to avoid deleting a directory 
-            # marker before the directory is empty. If these are deleted out of order 
+            # marker before the directory is empty. If these are deleted out of order we will get 
+            # `This operation is not permitted on a non-empty directory.` on hierarchical namespace storage accounts.
             for directory_marker in reversed(directory_markers):
                 cc.delete_blob(directory_marker)
 

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1197,12 +1197,19 @@ class AzureBlobFileSystem(AsyncFileSystem):
         async with self.service_client.get_container_client(
             container=container_name
         ) as cc:
+            print(files)
+            blobs = [file for file in files if not file.endswith("/")]
+            print(blobs)
+            directory_markers = [file for file in files if file.endswith("/")]
+            print(directory_markers)
             file_exs = await asyncio.gather(
-                *([cc.delete_blob(file) for file in files if not file.endswith("/")]), return_exceptions=True
+                *([cc.delete_blob(file) for file in blobs]), return_exceptions=True
             )
+            print("deleted blobs")
             directory_marker_exs = await asyncio.gather(
-                *([cc.delete_blob(file) for file in files if file.endswith("/")]), return_exceptions=True
+                *([cc.delete_blob(file) for file in directory_markers]), return_exceptions=True
             )
+            print("deleted directory markers")
             for ex in file_exs + directory_marker_exs:
                 if ex is not None:
                     raise ex

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1125,11 +1125,11 @@ class AzureBlobFileSystem(AsyncFileSystem):
 
     async def _rm(
         self,
-        path,
-        recursive=False,
-        maxdepth=None,
-        delimiter="/",
-        expand_path=True,
+        path: typing.Union[str, typing.List[str]],
+        recursive: bool = False,
+        maxdepth: typing.Optional[int] = None,
+        delimiter: str = "/",
+        expand_path: bool = True,
         **kwargs,
     ):
         """Delete files.
@@ -1186,13 +1186,13 @@ class AzureBlobFileSystem(AsyncFileSystem):
 
     rm = sync_wrapper(_rm)
 
-    async def _rm_files(self, container_name, file_paths, **kwargs):
+    async def _rm_files(self, container_name: str, file_paths: typing.Iterable[str], **kwargs):
         """
         Delete the given file(s)
 
         Parameters
         ----------
-        path: str or list of str
+        file_paths: iterable of str
             File(s) to delete.
         """
         async with self.service_client.get_container_client(

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1197,10 +1197,13 @@ class AzureBlobFileSystem(AsyncFileSystem):
         async with self.service_client.get_container_client(
             container=container_name
         ) as cc:
-            exs = await asyncio.gather(
-                *([cc.delete_blob(file) for file in files]), return_exceptions=True
+            file_exs = await asyncio.gather(
+                *([cc.delete_blob(file) for file in files if not file.endswith("/")]), return_exceptions=True
             )
-            for ex in exs:
+            directory_marker_exs = await asyncio.gather(
+                *([cc.delete_blob(file) for file in files if file.endswith("/")]), return_exceptions=True
+            )
+            for ex in file_exs + directory_marker_exs:
                 if ex is not None:
                     raise ex
         for file in files:

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1214,7 +1214,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
             for directory_marker in reversed(directory_markers):
                 cc.delete_blob(directory_marker)
 
-        for file in files:
+        for file in file_paths:
             self.invalidate_cache(self._parent(file))
 
     sync_wrapper(_rm_files)
@@ -1228,12 +1228,11 @@ class AzureBlobFileSystem(AsyncFileSystem):
         directory_markers = []
         files = [unique_sorted_file_paths[-1]]  # The last file lexographically cannot be a directory marker for a non-empty directory. 
         
-        for file, next_file in zip(files, files[1:]):
-            # /path/to/directory -- file that looks similar to a directory marker
-            # /path/to/directory/ -- directory marker
+        for file, next_file in zip(unique_sorted_file_paths, unique_sorted_file_paths[1:]):
+            # /path/to/directory -- directory marker
             # /path/to/directory/file  -- file in directory
             # /path/to/directory2/file -- file in different directory
-            if file.endswith("/") and next_file.startswith(file):
+            if next_file.startswith(file + "/"):
                 directory_markers.append(file)
             else:
                 files.append(file)

--- a/adlfs/tests/conftest.py
+++ b/adlfs/tests/conftest.py
@@ -28,7 +28,7 @@ def host(request):
     return request.config.getoption("--host")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def storage(host):
     """
     Create blob using azurite.
@@ -56,6 +56,7 @@ def storage(host):
     container_client.upload_blob("root/e+f/file2.txt", data)
     yield bbs
 
+    bbs.delete_container("data")
 
 @pytest.fixture(scope="session")
 def event_loop():

--- a/adlfs/tests/conftest.py
+++ b/adlfs/tests/conftest.py
@@ -58,6 +58,7 @@ def storage(host):
 
     bbs.delete_container("data")
 
+
 @pytest.fixture(scope="session")
 def event_loop():
     policy = asyncio.get_event_loop_policy()

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -403,10 +403,14 @@ def test_time_info(storage):
     )
 
     creation_time = fs.created("data/root/d/file_with_metadata.txt")
-    assert_almost_equal(creation_time, storage.insert_time, datetime.timedelta(seconds=1))
+    assert_almost_equal(
+        creation_time, storage.insert_time, datetime.timedelta(seconds=1)
+    )
 
     modified_time = fs.modified("data/root/d/file_with_metadata.txt")
-    assert_almost_equal(modified_time, storage.insert_time, datetime.timedelta(seconds=1))
+    assert_almost_equal(
+        modified_time, storage.insert_time, datetime.timedelta(seconds=1)
+    )
 
 
 def test_find(storage):

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -763,17 +763,7 @@ def test_rm_recursive2(mock_delete_blob, storage):
     )
 
     assert "data/root" in fs.ls("/data")
-
-    # print(fs.ls("/data/", invalidate_cache=True))
-    # assert fs.ls("/data/*") == [
-    #     "data/root/a",
-    #     "data/root/a1",
-    #     "data/root/b",
-    #     "data/root/c",
-    #     "data/root/d",
-    #     "data/root/e+f",
-    #     "data/root/rfile.txt",
-    # ]
+    
     fs.rm("data/root", recursive=True)
     assert "data/root" not in fs.ls("/data")
 

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -775,7 +775,6 @@ def test_rm_recursive2(mock_delete_blob, storage):
         fs.ls("data/root")
 
     last_deleted_paths = [call.args[1] for call in mock_delete_blob.mock_calls[-7:]]
-    print(last_deleted_paths)
     assert last_deleted_paths == [
         "root/e+f",
         "root/d",

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -403,10 +403,10 @@ def test_time_info(storage):
     )
 
     creation_time = fs.created("data/root/d/file_with_metadata.txt")
-    assert creation_time == storage.insert_time
+    assert_almost_equal(creation_time, storage.insert_time, datetime.timedelta(seconds=1))
 
     modified_time = fs.modified("data/root/d/file_with_metadata.txt")
-    assert modified_time == storage.insert_time
+    assert_almost_equal(modified_time, storage.insert_time, datetime.timedelta(seconds=1))
 
 
 def test_find(storage):
@@ -763,7 +763,7 @@ def test_rm_recursive2(mock_delete_blob, storage):
     )
 
     assert "data/root" in fs.ls("/data")
-    
+
     fs.rm("data/root", recursive=True)
     assert "data/root" not in fs.ls("/data")
 


### PR DESCRIPTION
Resolves: https://github.com/fsspec/adlfs/issues/389

Alternative fix to https://github.com/fsspec/adlfs/pull/453

Unfortunately https://github.com/fsspec/adlfs/pull/383 broke recursive delete on blob storage accounts with hierarchical namespace enabled (ADLS gen2). 

```
azure.core.exceptions.ResourceExistsError: This operation is not permitted on a non-empty directory.
RequestId:f3042353-701e-0069-7a68-dc7b41000000
Time:2023-09-01T00:08:11.0327332Z
ErrorCode:DirectoryIsNotEmpty
Content: <?xml version="1.0" encoding="utf-8"?><Error><Code>DirectoryIsNotEmpty</Code><Message>This operation is not permitted on a non-empty directory.
RequestId:f3042353-701e-0069-7a68-dc7b41000000
Time:2023-09-01T00:08:11.0327332Z</Message></Error>
```

This is because https://github.com/fsspec/adlfs/pull/383 causes all blobs (including hierarchical namespace directory markers) do be deleted asynchronously. There is nothing to ensure that the contents of a directory are deleted before the directory itself, hence the error above. 

### Chosen fix
Look at the sorted list of blob names to derive which blobs are directory markers so they can be deleted in the correct order. Other blobs are deleted asynchronously. The strategy used for this is a bit strange but I think its the best option, at least for now. 

### Alternative solutions:
1. `container_client.delete_blobs()`
    1. A single call to Azure makes a batch delete. Not sure how the performance will compare to the async single deleted that we do. 
    2. This looks like its works on hierarchical and flat namespaces storage accounts but it doesn't work on `azurite` https://github.com/Azure/Azurite/issues/1809
    3. Simple solution if we have a list of blobs to delete. 
1. Detect a hierarchical namespace accounts and follow a different code path
    1.  Detecting hierarchical namespace is shockingly difficult to do e.g. https://github.com/apache/arrow/blob/667e9170ef363e9b4a067be3be245d2dcd4b7a6f/cpp/src/arrow/filesystem/azurefs.cc#L832-L879
    1. The `delete_directory` API on hierarchical namespace accounts can automatically delete the directory recursively with no need to explicitly list all the blobs it contains https://learn.microsoft.com/en-us/python/api/azure-storage-file-datalake/azure.storage.filedatalake.datalakedirectoryclient?view=azure-python#azure-storage-filedatalake-datalakedirectoryclient-delete-directory
1. Read the blob metadata to look for directory markers
    1. Directory markers on hierarchical namespace accounts have the metadata `Hdi_isfolder=true`. 
    2. This would be a simple and robust way to detect directory marker blobs that must be deleted in the correct order. 
    3. Unfortunately it will be a big performance cost to query the metadata of all these blobs unnecessarily. It seems like https://github.com/fsspec/adlfs/pull/383 added `expand_path=False` specifically to get this optimisation. 

### Testing
The currently existing test `test_rm_recursive` catches this bug if it is run against a hierarchical namespace storage account. I provisioned a real hierarchical namespace account to run this test against. 
I added an assertion to `test_rm_recursive` that the directory marker is the last delete. 
I also added a test that deletes more directories. To implement this I changed the `storage` fixture to have `function` scope to reset it after every test. This doesn't seem to impact the runtime of the tests so I assume this is ok. 