### PR TITLE
Fix missing kwargs injection on put calls

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1627,6 +1627,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                             ),
                             max_concurrency=max_concurrency or self.max_concurrency,
                             **self._timeout_kwargs,
+                            **kwargs,
                         )
                 self.invalidate_cache()
             except ResourceExistsError:


### PR DESCRIPTION
While https://github.com/fsspec/adlfs/pull/392 was supposed to fix https://github.com/fsspec/adlfs/issues/294, it did not. When uploading a file using `fs.put`, `kwargs` is still not being forwarded, because these calls are passed to `_put_file` which does not rely on `_pipe`, unlike `write_*` calls.

This PR is very simple: also injects kwargs on `bc.upload_blob` for the `_put_file` calls.