### PR TITLE
add missing await on delete_blob call per issue 459

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1220,7 +1220,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
             # marker before the directory is empty. If these are deleted out of order we will get
             # `This operation is not permitted on a non-empty directory.` on hierarchical namespace storage accounts.
             for directory_marker in reversed(directory_markers):
-                cc.delete_blob(directory_marker)
+                await cc.delete_blob(directory_marker)
 
         for file in file_paths:
             self.invalidate_cache(self._parent(file))

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -809,7 +809,6 @@ async def test_rm_recursive_call_order(storage, mocker):
     ], "The directory deletion should be in reverse lexographical order"
 
 
-
 def test_rm_multiple_items(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -762,7 +762,6 @@ def test_rm_recursive2(storage):
     assert "data/root" in fs.ls("/data")
 
     fs.rm("data/root", recursive=True)
-
     assert "data/root" not in fs.ls("/data")
 
     with pytest.raises(FileNotFoundError):


### PR DESCRIPTION
per https://github.com/fsspec/adlfs/issues/459

add missing await on `delete_blob`