### PR TITLE
document that `credential` needs to be from azure.identity.aio

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -147,7 +147,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         request session. See
         http://azure.microsoft.com/en-us/documentation/articles/storage-configure-connection-string/
         for the connection string format.
-    credential: azure.core.credentials.AsyncTokenCredential or SAS token
+    credential: azure.core.credentials_async.AsyncTokenCredential or SAS token
         The credentials with which to authenticate.  Optional if the account URL already has a SAS token.
         Can include an instance of TokenCredential class from azure.identity.aio.
     blocksize: int

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -147,7 +147,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         request session. See
         http://azure.microsoft.com/en-us/documentation/articles/storage-configure-connection-string/
         for the connection string format.
-    credential: (async!) TokenCredential or SAS token
+    credential: azure.core.credentials.AsyncTokenCredential or SAS token
         The credentials with which to authenticate.  Optional if the account URL already has a SAS token.
         Can include an instance of TokenCredential class from azure.identity.aio.
     blocksize: int

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -147,9 +147,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
         request session. See
         http://azure.microsoft.com/en-us/documentation/articles/storage-configure-connection-string/
         for the connection string format.
-    credential: TokenCredential or SAS token
+    credential: (async!) TokenCredential or SAS token
         The credentials with which to authenticate.  Optional if the account URL already has a SAS token.
-        Can include an instance of TokenCredential class from azure.identity
+        Can include an instance of TokenCredential class from azure.identity.aio.
     blocksize: int
         The block size to use for download/upload operations. Defaults to hardcoded value of
         ``BlockBlobService.MAX_BLOCK_SIZE``


### PR DESCRIPTION
if it's a sync credential, then the weakref.finalize callback will cause an error, `close() -> None` cannot be awaited.