### PR TITLE
Honor the anon parameter if set

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -277,11 +277,14 @@ class AzureBlobFileSystem(AsyncFileSystem):
         self.client_id = client_id or os.getenv("AZURE_STORAGE_CLIENT_ID")
         self.client_secret = client_secret or os.getenv("AZURE_STORAGE_CLIENT_SECRET")
         self.tenant_id = tenant_id or os.getenv("AZURE_STORAGE_TENANT_ID")
-        self.anon = anon or os.getenv("AZURE_STORAGE_ANON", "true").lower() not in [
-            "false",
-            "0",
-            "f",
-        ]
+        if anon is not None:
+            self.anon = anon
+        else:
+            self.anon = os.getenv("AZURE_STORAGE_ANON", "true").lower() not in [
+                "false",
+                "0",
+                "f",
+            ]
         self.location_mode = location_mode
         self.credential = credential
         self.request_session = request_session


### PR DESCRIPTION
If the anon parameter is set, it should be used over any environment variables set.

Fixes #467 