### PR TITLE
support signed urls via connection string alone

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -22,6 +22,7 @@ from azure.core.exceptions import (
     ResourceExistsError,
     ResourceNotFoundError,
 )
+from azure.core.utils import parse_connection_string
 from azure.storage.blob import (
     BlobBlock,
     BlobProperties,
@@ -1541,11 +1542,19 @@ class AzureBlobFileSystem(AsyncFileSystem):
         """
         container_name, blob, version_id = self.split_path(path)
 
+        if self.connection_string:
+            args_dict = parse_connection_string(self.connection_string)
+            account_name = args_dict.get("accountname")
+            account_key = args_dict.get("accountkey")
+        else:
+            account_name = self.account_name
+            account_key = self.account_key
+
         sas_token = generate_blob_sas(
-            account_name=self.account_name,
+            account_name=account_name,
             container_name=container_name,
             blob_name=blob,
-            account_key=self.account_key,
+            account_key=account_key,
             permission=BlobSasPermissions(read=True),
             expiry=datetime.utcnow() + timedelta(seconds=expires),
             version_id=version_id,

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1629,6 +1629,26 @@ async def test_url_versioned(storage, mocker):
     )
 
 
+async def test_url_with_conn_str(mocker):
+    fs = AzureBlobFileSystem(connection_string=CONN_STR)
+    generate_blob_sas = mocker.patch("adlfs.spec.generate_blob_sas")
+
+    await fs._url("data/root/a/file.txt")
+    generate_blob_sas.assert_called_once_with(
+        account_name=ACCOUNT_NAME,
+        container_name="data",
+        blob_name="root/a/file.txt",
+        account_key=KEY,
+        permission=mocker.ANY,
+        expiry=mocker.ANY,
+        version_id=None,
+        content_disposition=None,
+        content_encoding=None,
+        content_language=None,
+        content_type=None,
+    )
+
+
 def test_cp_file(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR


### PR DESCRIPTION
In a lot of cases we have only a connection and no account name, account key. Those could be extracted from the connection string and it's convenient to have it done automatically by the fs itself.