### PR TITLE
Implement exclusive mode

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -2111,9 +2111,7 @@ class AzureBlobFile(AbstractBufferedFile):
         if self.mode == "ab":
             if not await self.fs._exists(self.path):
                 async with self.container_client.get_blob_client(blob=self.blob) as bc:
-                    await bc.create_append_blob(
-                        metadata=self.metadata, overwrite=(self.mode == "wb")
-                    )
+                    await bc.create_append_blob(metadata=self.metadata)
 
     _initiate_upload = sync_wrapper(_async_initiate_upload)
 

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -5,9 +5,11 @@ from unittest import mock
 
 import azure.storage.blob.aio
 import dask.dataframe as dd
+import fsspec
 import numpy as np
 import pandas as pd
 import pytest
+from packaging.version import parse as parse_version
 from pandas.testing import assert_frame_equal
 
 from adlfs import AzureBlobFile, AzureBlobFileSystem
@@ -2020,6 +2022,10 @@ def test_put_file_x(storage: azure.storage.blob.BlobServiceClient, tmpdir):
     assert fs.cat_file("data/afile") == b"data"
 
 
+@pytest.mark.xfail(
+    parse_version(fsspec.__version__) < parse_version("2024.11.0"),
+    reason="not supported upstream yet",
+)
 def test_open_file_x(storage: azure.storage.blob.BlobServiceClient, tmpdir):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name,

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1982,3 +1982,60 @@ def test_hdi_isfolder_case(storage: azure.storage.blob.BlobServiceClient, key: s
 
     result = fs.info("data/folder")
     assert result["type"] == "directory"
+
+
+def test_pipe_file_x(storage: azure.storage.blob.BlobServiceClient):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        skip_instance_cache=True,
+        timeout=11,
+        connection_timeout=12,
+        read_timeout=13,
+    )
+    fs.pipe_file("data/afile", b"data", mode="create")  # ok
+    fs.pipe_file("data/afile", b"data2")  # ok
+    with pytest.raises(FileExistsError):
+        fs.pipe_file("data/afile", b"data3", mode="create")
+    assert fs.cat_file("data/afile") == b"data2"
+
+
+def test_put_file_x(storage: azure.storage.blob.BlobServiceClient, tmpdir):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        skip_instance_cache=True,
+        timeout=11,
+        connection_timeout=12,
+        read_timeout=13,
+    )
+    fn = f"{tmpdir}/afile"
+    with open(fn, "wb") as f:
+        f.write(b"data")
+    fs.put_file(fn, "data/afile", mode="create")  # ok
+    fs.put_file(fn, "data/afile")  # ok
+    with pytest.raises(FileExistsError):
+        fs.put_file(fn, "data/afile", mode="create")
+
+    assert fs.cat_file("data/afile") == b"data"
+
+
+def test_open_file_x(storage: azure.storage.blob.BlobServiceClient, tmpdir):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+        skip_instance_cache=True,
+        timeout=11,
+        connection_timeout=12,
+        read_timeout=13,
+    )
+    with fs.open("data/afile", "xb") as f:
+        f.write(b"data")
+    with pytest.raises(FileExistsError):
+        with fs.open("data/afile", "xb") as f:
+            f.write(b"data2")
+    with pytest.raises(FileExistsError):
+        # zero-length file has a different codepath
+        with fs.open("data/afile", "xb") as f:
+            pass
+    assert fs.cat_file("data/afile") == b"data"

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2023,7 +2023,7 @@ def test_put_file_x(storage: azure.storage.blob.BlobServiceClient, tmpdir):
 
 
 @pytest.mark.xfail(
-    parse_version(fsspec.__version__) < parse_version("2024.11.0"),
+    parse_version(fsspec.__version__) <= parse_version("2024.11.0"),
     reason="not supported upstream yet",
 )
 def test_open_file_x(storage: azure.storage.blob.BlobServiceClient, tmpdir):

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2023,7 +2023,7 @@ def test_put_file_x(storage: azure.storage.blob.BlobServiceClient, tmpdir):
 
 
 @pytest.mark.xfail(
-    parse_version(fsspec.__version__) <= parse_version("2024.11.0"),
+    parse_version(fsspec.__version__) <= parse_version("2024.10.0"),
     reason="not supported upstream yet",
 )
 def test_open_file_x(storage: azure.storage.blob.BlobServiceClient, tmpdir):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 -r base.txt
-git+https://github.com/intake/filesystem_spec
+git+https://github.com/fsspec/filesystem_spec
 azure-core
 azure-datalake-store
 azure-storage-blob

--- a/requirements/latest.txt
+++ b/requirements/latest.txt
@@ -1,5 +1,5 @@
 -r base.txt
-fsspec
+git+http://github.com/fsspec/filesystem_spec
 azure-core<2.0.0
 azure-datalake-store
 azure-storage-blob

--- a/requirements/latest.txt
+++ b/requirements/latest.txt
@@ -1,5 +1,5 @@
 -r base.txt
-git+http://github.com/fsspec/filesystem_spec
+fsspec
 azure-core<2.0.0
 azure-datalake-store
 azure-storage-blob


### PR DESCRIPTION
This API matches that in fsspec (and s3fs, gcsfs) but does not remove the existing `overwrite=` kwarg. Now also applies to `mode="xb"` files.