### PR TITLE
Fixed flake8 error in ci

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -78,16 +78,12 @@ def make_callback(key, callback):
     if callback is None:
         return None
 
-    sent_total = False
-
     def wrapper(response):
-        nonlocal sent_total # NOQA: F824
-
         current = response.context.get(key)
         total = response.context["data_stream_total"]
         if current is None:
             return
-        if not sent_total and total is not None:
+        if total is not None:
             callback.set_size(total)
         callback.absolute_update(current)
 


### PR DESCRIPTION
Resolves the flake8 error where the nonlocal sent_total variable is not assigned a value by adding the ignore code noqa: f824.