### PR TITLE
Added skipApiVersionCheck for Azurite

### DIFF
--- a/adlfs/tests/conftest.py
+++ b/adlfs/tests/conftest.py
@@ -65,7 +65,7 @@ def spawn_azurite():
     client = docker.from_env()
     azurite = client.containers.run(
         "mcr.microsoft.com/azure-storage/azurite",
-        "azurite-blob --loose --blobHost 0.0.0.0",
+        "azurite-blob --loose --blobHost 0.0.0.0 --skipApiVersionCheck",
         detach=True,
         ports={"10000": "10000"},
     )


### PR DESCRIPTION
Added the skipApiVersionCheck flag to Azurite to get the tests to pass since Azurite does not support the [latest API version](https://github.com/fsspec/adlfs/issues/505). 