### PR TITLE
Faster file-like writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Unreleased
 - The block size is now used for partitioned uploads. Previously, 1 GiB was used for each uploaded block irrespective of the block size  
 - Updated default block size to be 50 MiB. Set `blocksize` for `AzureBlobFileSystem` or `block_size` when opening `AzureBlobFile` to revert back to 5 MiB default. 
 - `AzureBlobFile` now inherits the block size from `AzureBlobFileSystem` when fs.open() is called and a block_size is not passed in.
-- Added concurrency for `_async_upload_chunk`. Can be set using `max_concurrency` for `AzureBlobFileSystem`.
+- Introduce concurrent uploads for large `AzureBlobFileSystem.write()` calls. Maximum concurrency can be set using `max_concurrency` for `AzureBlobFileSystem`.
 
 
 2024.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased
 - The block size is now used for partitioned uploads. Previously, 1 GiB was used for each uploaded block irrespective of the block size  
 - Updated default block size to be 50 MiB. Set `blocksize` for `AzureBlobFileSystem` or `block_size` when opening `AzureBlobFile` to revert back to 5 MiB default. 
 - `AzureBlobFile` now inherits the block size from `AzureBlobFileSystem` when fs.open() is called and a block_size is not passed in.
+- Added concurrency for `_async_upload_chunk`. Can be set using `max_concurrency` for `AzureBlobFileSystem`.
 
 
 2024.12.0

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -2156,17 +2156,9 @@ class AzureBlobFile(AbstractBufferedFile):
             yield data[start:end]
             start = end
 
-    async def _async_upload_chunk(self, final: bool = False, **kwargs):
-        """
-        Write one part of a multi-block file upload
-
-        Parameters
-        ----------
-        final: bool
-            This is the last block, so should complete file, if
-            self.autocommit is True.
-
-        """
+    async def _async_upload_chunk(
+        self, final: bool = False, max_concurrency=None, **kwargs
+    ):
         data = self.buffer.getvalue()
         length = len(data)
         block_id = self._get_block_id(self._block_list)
@@ -2175,18 +2167,31 @@ class AzureBlobFile(AbstractBufferedFile):
             commit_kw["headers"] = {"If-None-Match": "*"}
         if self.mode in {"wb", "xb"}:
             try:
-                for chunk in self._get_chunks(data):
-                    async with self.container_client.get_blob_client(
-                        blob=self.blob
-                    ) as bc:
-                        await bc.stage_block(
-                            block_id=block_id,
-                            data=chunk,
-                            length=len(chunk),
-                        )
-                        self._block_list.append(block_id)
-                        block_id = self._get_block_id(self._block_list)
+                max_concurrency = max_concurrency or self.fs.max_concurrency or 1
+                semaphore = asyncio.Semaphore(max_concurrency)
+                tasks = []
+                block_ids = []
+                chunks = list(self._get_chunks(data))
+                for _ in range(len(chunks)):
+                    block_ids.append(block_id)
+                    block_id = self._get_block_id(block_ids)
+                if chunks:
+                    self._block_list = block_ids
+                for chunk, block_id in zip(chunks, block_ids):
 
+                    async def _upload_chunk(chunk=chunk, block_id=block_id):
+                        async with semaphore:
+                            async with self.container_client.get_blob_client(
+                                blob=self.blob
+                            ) as bc:
+                                await bc.stage_block(
+                                    block_id=block_id,
+                                    data=chunk,
+                                    length=len(chunk),
+                                )
+
+                    tasks.append(_upload_chunk())
+                await asyncio.gather(*tasks)
                 if final:
                     block_list = [BlobBlock(_id) for _id in self._block_list]
                     async with self.container_client.get_blob_client(

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -2159,6 +2159,16 @@ class AzureBlobFile(AbstractBufferedFile):
     async def _async_upload_chunk(
         self, final: bool = False, max_concurrency=None, **kwargs
     ):
+        """
+        Write one part of a multi-block file upload
+
+        Parameters
+        ----------
+        final: bool
+            This is the last block, so should complete file, if
+            self.autocommit is True.
+
+        """
         data = self.buffer.getvalue()
         length = len(data)
         block_id = self._get_block_id(self._block_list)

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -2161,7 +2161,7 @@ class AzureBlobFile(AbstractBufferedFile):
             async with self.container_client.get_blob_client(blob=self.blob) as bc:
                 await bc.stage_block(
                     block_id=block_id,
-                    data=data[start:end],
+                    data=bytes(data[start:end]),
                     length=end - start,
                 )
                 return block_id

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -2165,9 +2165,7 @@ class AzureBlobFile(AbstractBufferedFile):
                     length=len(chunk),
                 )
 
-    async def _async_upload_chunk(
-        self, final: bool = False, max_concurrency=None, **kwargs
-    ):
+    async def _async_upload_chunk(self, final: bool = False, **kwargs):
         """
         Write one part of a multi-block file upload
 
@@ -2186,7 +2184,7 @@ class AzureBlobFile(AbstractBufferedFile):
             commit_kw["headers"] = {"If-None-Match": "*"}
         if self.mode in {"wb", "xb"}:
             try:
-                max_concurrency = max_concurrency or self.fs.max_concurrency or 1
+                max_concurrency = self.fs.max_concurrency
                 semaphore = asyncio.Semaphore(max_concurrency)
                 tasks = []
                 block_ids = self._block_list or []

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -9,9 +9,9 @@ import io
 import logging
 import os
 import re
+import sys
 import typing
 import warnings
-import sys
 import weakref
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -2189,7 +2189,7 @@ class AzureBlobFile(AbstractBufferedFile):
         commit_kw = {}
         if self.mode == "xb":
             commit_kw["headers"] = {"If-None-Match": "*"}
-        if self.mode in {"wb", "xb"}:  
+        if self.mode in {"wb", "xb"}:
             try:
                 max_concurrency = self.fs.max_concurrency or 1
                 semaphore = asyncio.Semaphore(max_concurrency)
@@ -2287,4 +2287,3 @@ class AzureBlobFile(AbstractBufferedFile):
         # We still want to leverage memorviews when we can to avoid unnecessary copies. So
         # we check the Python version to determine if we can use memoryviews for writes.
         return sys.version_info >= (3, 10)
-    

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -2195,7 +2195,7 @@ class AzureBlobFile(AbstractBufferedFile):
                         self._stage_block(data, start, end, block_id, semaphore)
                     )
                     block_id = self._get_block_id(self._block_list)
-                ids = await asyncio.gather(*tasks, return_exceptions=True)
+                ids = await asyncio.gather(*tasks)
                 self._block_list.extend(ids[1:])
 
                 if final:

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1,6 +1,8 @@
 import datetime
 import math
 import os
+import random
+import string
 import tempfile
 from unittest import mock
 
@@ -2143,22 +2145,26 @@ def test_blobfile_default_blocksize(storage):
 
 
 @pytest.mark.parametrize(
-    "max_concurrency, blob_size",
+    "max_concurrency, blob_size, blocksize",
     [
-        (1, 51 * 2**20),
-        (4, 200 * 2**20),
-        (4, 49 * 2**20),
+        (None, 200 * 2**20, 5 * 2**20),
+        (1, 51 * 2**20, 50 * 2**20),
+        (4, 200 * 2**20, 50 * 2**20),
+        (4, 49 * 2**20, 50 * 2**20),
+        (4, 200 * 2**20, 5 * 2**20),
     ],
 )
-def test_max_concurrency(storage, max_concurrency, blob_size):
+def test_write_max_concurrency(storage, max_concurrency, blob_size, blocksize):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name,
         connection_string=CONN_STR,
+        blocksize=blocksize,
         max_concurrency=max_concurrency,
     )
     data = os.urandom(blob_size)
-    fs.mkdir("large-file-container")
-    path = "large-file-container/blob.txt"
+    container_name = "".join(random.choices(string.ascii_lowercase, k=10))
+    fs.mkdir(container_name)
+    path = f"{container_name}/blob.txt"
 
     with fs.open(path, "wb") as f:
         f.write(data)
@@ -2168,3 +2174,4 @@ def test_max_concurrency(storage, max_concurrency, blob_size):
 
     with fs.open(path, "rb") as f:
         assert f.read() == data
+    fs.rm(container_name, recursive=True)

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2142,20 +2142,26 @@ def test_blobfile_default_blocksize(storage):
     assert f.blocksize == 50 * 2**20
 
 
-@pytest.mark.parametrize("max_concurrency", [1, 2, 4, 8])
-def test_large_blob_max_concurrency(storage, max_concurrency):
+@pytest.mark.parametrize(
+    "max_concurrency, blob_size",
+    [
+        (1, 51 * 2**20),
+        (4, 200 * 2**20),
+        (4, 49 * 2**20),
+    ],
+)
+def test_max_concurrency(storage, max_concurrency, blob_size):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name,
         connection_string=CONN_STR,
         max_concurrency=max_concurrency,
     )
-    blob_size = 1_120_000_000
     data = os.urandom(blob_size)
     fs.mkdir("large-file-container")
-    path = "large-file-container/blob.bin"
+    path = "large-file-container/blob.txt"
 
-    with fs.open(path, "wb") as dst:
-        dst.write(data)
+    with fs.open(path, "wb") as f:
+        f.write(data)
 
     assert fs.exists(path)
     assert fs.size(path) == blob_size


### PR DESCRIPTION
Utilized the max_concurrency argument to allow concurrent writes in the _async_upload_chunk function.