### PR TITLE
updated default block size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Unreleased
 - Fix issue where ``AzureBlobFile`` did not respect ``location_mode`` parameter
   from parent ``AzureBlobFileSystem`` when using SAS credentials and connecting to
   new SDK clients.
-- The block size is now used for uploads. Previously, it was always 1 GiB irrespective of the block size  
-- Updated default block size to be 50 MiB 
+- The block size is now used for partitioned uploads. Previously, 1 GiB was used for each uploaded block irrespective of the block size  
+- Updated default block size to be 50 MiB. Set `blocksize` for `AzureBlobFileSystem` or `block_size` when opening `AzureBlobFile` to revert back to 5 MiB default. 
 - `AzureBlobFile` now inherits the block size from `AzureBlobFileSystem` when fs.open() is called and a block_size is not passed in.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Unreleased
 - Fix issue where ``AzureBlobFile`` did not respect ``location_mode`` parameter
   from parent ``AzureBlobFileSystem`` when using SAS credentials and connecting to
   new SDK clients.
+- The block size is now used for uploads. Previously, it was always 1 GiB irrespective of the block size  
+- Updated default block size to be 50 MiB 
+- `AzureBlobFile` now inherits the block size from `AzureBlobFileSystem` when fs.open() is called and a block_size is not passed in.
 
 
 2024.12.0

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2050,6 +2050,7 @@ def test_open_file_x(storage: azure.storage.blob.BlobServiceClient, tmpdir):
 
 def test_number_of_blocks(storage, mocker):
     from azure.storage.blob.aio import BlobClient
+
     blocksize = 5 * 2**20
     fs = AzureBlobFileSystem(
         account_name=storage.account_name,
@@ -2065,20 +2066,22 @@ def test_number_of_blocks(storage, mocker):
         expected_blocks = math.ceil(len(content) / blocksize)
         actual_blocks = mock_stage_block.call_count
         assert actual_blocks == expected_blocks
-        block_lengths = [call.kwargs["length"] for call in mock_stage_block.call_args_list]
+        block_lengths = [
+            call.kwargs["length"] for call in mock_stage_block.call_args_list
+        ]
         assert sum(block_lengths) == len(content)
 
     assert len(mock_commit_block_list.call_args.kwargs["block_list"]) == expected_blocks
 
 
 @pytest.mark.parametrize(
-        "filesystem_blocksize, file_blocksize, expected_blocksize",
-        [
-            (None, None, 50 * 2**20),
-            (50 * 2**20, None, 50 * 2**20),
-            (None, 5 * 2**20, 5 * 2**20),
-            (50 * 2**20, 7 * 2**20, 7 * 2**20),
-        ]
+    "filesystem_blocksize, file_blocksize, expected_blocksize",
+    [
+        (None, None, 50 * 2**20),
+        (50 * 2**20, None, 50 * 2**20),
+        (None, 5 * 2**20, 5 * 2**20),
+        (50 * 2**20, 7 * 2**20, 7 * 2**20),
+    ],
 )
 def test_block_size(storage, filesystem_blocksize, file_blocksize, expected_blocksize):
     fs = AzureBlobFileSystem(
@@ -2092,11 +2095,11 @@ def test_block_size(storage, filesystem_blocksize, file_blocksize, expected_bloc
 
 
 @pytest.mark.parametrize(
-        "file_blocksize, expected_blocksize",
-        [
-            (None, 50 * 2**20),  
-            (8 * 2**20, 8 * 2**20),
-        ]
+    "file_blocksize, expected_blocksize",
+    [
+        (None, 50 * 2**20),
+        (8 * 2**20, 8 * 2**20),
+    ],
 )
 def test_blocksize_from_blobfile(storage, file_blocksize, expected_blocksize):
     fs = AzureBlobFileSystem(
@@ -2105,7 +2108,7 @@ def test_blocksize_from_blobfile(storage, file_blocksize, expected_blocksize):
     f = AzureBlobFile(
         fs,
         "data/root/a/file.txt",
-        block_size=file_blocksize,  
+        block_size=file_blocksize,
     )
     assert f.blocksize == expected_blocksize
     assert fs.blocksize == 50 * 2**20
@@ -2122,4 +2125,3 @@ def test_override_blocksize(storage):
     assert f.blocksize == 50 * 2**20
     f.blocksize = 2 * 2**20
     assert f.blocksize == 2 * 2**20
-

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -3,7 +3,6 @@ import math
 import os
 import tempfile
 from unittest import mock
-from unittest.mock import patch
 
 import azure.storage.blob.aio
 import dask.dataframe as dd
@@ -2049,35 +2048,78 @@ def test_open_file_x(storage: azure.storage.blob.BlobServiceClient, tmpdir):
     assert fs.cat_file("data/afile") == b"data"
 
 
-@pytest.mark.parametrize("blocksize", [5 * 2**20, 50 * 2**20, 100 * 2**20])
-def test_number_of_blocks(storage, mocker, blocksize):
-
+def test_number_of_blocks(storage, mocker):
+    from azure.storage.blob.aio import BlobClient
+    blocksize = 5 * 2**20
     fs = AzureBlobFileSystem(
         account_name=storage.account_name,
         connection_string=CONN_STR,
         blocksize=blocksize,
     )
 
-    content = b"1" * (blocksize * 2 + 1)
-    with fs.open("data/root/a/file.txt", "wb", blocksize=blocksize) as f:
-        mocker.patch(
-            "azure.storage.blob.aio.BlobClient.commit_block_list", autospec=True
-        )
-        with patch(
-            "azure.storage.blob.aio.BlobClient.stage_block", autospec=True
-        ) as mock_stage_block:
-            f.write(content)
-            expected_blocks = math.ceil(len(content) / blocksize)
-            actual_blocks = mock_stage_block.call_count
-            assert actual_blocks == expected_blocks
+    content = b"1" * (blocksize * 4 + 1)
+    with fs.open("data/root/a/file.txt", "wb") as f:
+        mock_stage_block = mocker.patch.object(BlobClient, "stage_block")
+        mock_commit_block_list = mocker.patch.object(BlobClient, "commit_block_list")
+        f.write(content)
+        expected_blocks = math.ceil(len(content) / blocksize)
+        actual_blocks = mock_stage_block.call_count
+        assert actual_blocks == expected_blocks
+        block_lengths = [call.kwargs["length"] for call in mock_stage_block.call_args_list]
+        assert sum(block_lengths) == len(content)
+
+    assert len(mock_commit_block_list.call_args.kwargs["block_list"]) == expected_blocks
 
 
-def test_block_size(storage):
+@pytest.mark.parametrize(
+        "filesystem_blocksize, file_blocksize, expected_blocksize",
+        [
+            (None, None, 50 * 2**20),
+            (50 * 2**20, None, 50 * 2**20),
+            (None, 5 * 2**20, 5 * 2**20),
+            (50 * 2**20, 7 * 2**20, 7 * 2**20),
+        ]
+)
+def test_block_size(storage, filesystem_blocksize, file_blocksize, expected_blocksize):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name,
         connection_string=CONN_STR,
-        blocksize=5 * 2**20,
+        blocksize=filesystem_blocksize,
     )
 
-    with fs.open("data/root/a/file.txt", "wb") as f:
-        assert f.blocksize == 5 * 2**20
+    with fs.open("data/root/a/file.txt", "wb", block_size=file_blocksize) as f:
+        assert f.blocksize == expected_blocksize
+
+
+@pytest.mark.parametrize(
+        "file_blocksize, expected_blocksize",
+        [
+            (None, 50 * 2**20),  
+            (8 * 2**20, 8 * 2**20),
+        ]
+)
+def test_blocksize_from_blobfile(storage, file_blocksize, expected_blocksize):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    f = AzureBlobFile(
+        fs,
+        "data/root/a/file.txt",
+        block_size=file_blocksize,  
+    )
+    assert f.blocksize == expected_blocksize
+    assert fs.blocksize == 50 * 2**20
+
+
+def test_override_blocksize(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    f = AzureBlobFile(
+        fs,
+        "data/root/a/file.txt",
+    )
+    assert f.blocksize == 50 * 2**20
+    f.blocksize = 2 * 2**20
+    assert f.blocksize == 2 * 2**20
+


### PR DESCRIPTION
Updated the default block size to be 50 MiB so AzureBlobFileSystem and AzureBlobFile are more consistent. This also addresses the [github issue](https://github.com/fsspec/adlfs/issues/494) where the chunk_size of 1GB results in a Timeout Error and also respects the block_size parameter sent in when opening a file. 

I also created this [gist ](https://gist.github.com/anjaliratnam-msft/26e070834411847f6f2cd40d4ec23642)to show that the performance is not impacted negatively when increasing the default from 5 to 50 MiB and performance improves when reducing the chunk size from 1 GB to 50 MiB.