### PR TITLE
Respect `protocol` tuple in removal from full URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 Unreleased
 ----------
 
+* Respect `AzureBlobFileSystem.protocol` tuple when removing protocols from fully-qualified
+  paths provided to `AzureBlobFileSystem` methods.
+
+
+2025.8.0
+--------
+
 - Added "adlfs" to library's default user agent
 - Fix issue where ``AzureBlobFile`` did not respect ``location_mode`` parameter
   from parent ``AzureBlobFileSystem`` when using SAS credentials and connecting to

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -261,7 +261,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
     ...                       'account_name': ACCOUNT_NAME, 'account_key': ACCOUNT_KEY,})
     """
 
-    protocol = "abfs"
+    protocol = ("abfs", "az", "abfss")
 
     def __init__(
         self,
@@ -398,7 +398,11 @@ class AzureBlobFileSystem(AsyncFileSystem):
 
         STORE_SUFFIX = ".dfs.core.windows.net"
         logger.debug(f"_strip_protocol for {path}")
-        if not path.startswith(("abfs://", "az://", "abfss://")):
+        if isinstance(cls.protocol, str):
+            protocol_startswith = (f"{cls.protocol}://",)
+        else:
+            protocol_startswith = tuple([f"{proto}://" for proto in cls.protocol])
+        if not path.startswith(protocol_startswith):
             path = path.lstrip("/")
             path = "abfs://" + path
         ops = infer_storage_options(path)

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -399,9 +399,13 @@ class AzureBlobFileSystem(AsyncFileSystem):
         STORE_SUFFIX = ".dfs.core.windows.net"
         logger.debug(f"_strip_protocol for {path}")
         if isinstance(cls.protocol, str):
+            # The protocol can be either a string or a tuple of strings.
+            # While the default protocol is a tuple, a user can override the protocol to be a string.
+            # So, this handles the case where the user has overridden the protocol, restricting
+            # supported protocols to a single string.
             protocol_startswith = (f"{cls.protocol}://",)
         else:
-            protocol_startswith = tuple([f"{proto}://" for proto in cls.protocol])
+            protocol_startswith = tuple(f"{proto}://" for proto in cls.protocol)
         if not path.startswith(protocol_startswith):
             path = path.lstrip("/")
             path = "abfs://" + path


### PR DESCRIPTION
Supersedes: https://github.com/fsspec/adlfs/pull/493 and follows suggestion from this comment: https://github.com/fsspec/adlfs/pull/493#issuecomment-3192434961

This change makes `AzureBlobFileSystem` consistent with other fsspec implementations that use the `protocol` class tuple when stripping the protocol from fully qualified URIs. It also unblocks consumers to be able to update this `protocol` tuple if out of the box `adlfs` does not respect a particular protocol (e.g., deprecated `wasb://`).

Specifically, for pyiceberg and this PR to allow `wasb`/`wasbs`: https://github.com/apache/iceberg-python/pull/1663, it should be able to be updated to either update the tuple directly on the class e.g.:
```python
>>> from adlfs import AzureBlobFileSystem
>>> AzureBlobFileSystem.protocol = AzureBlobFileSystem.protocol + ("wasb", "wasbs")
>>> fs = AzureBlobFileSystem(account_name="myaccount")
>>> fs._strip_protocol("wasb://container/file")
'container/file'
>>> fs.split_path("wasb://container/file")
('container', 'file', None)
```
Or `AzureBlobFileSystem` can also be subclassed to add support for the protocols to avoid mutating the `adlfs` class e.g.:
```python
>>> from adlfs import AzureBlobFileSystem
>>> class WasbSupportedAzureBlobFileSystem(AzureBlobFileSystem):
...     protocol = AzureBlobFileSystem.protocol + ("wasb", "wasbs")

>>> fs = WasbSupportedAzureBlobFileSystem(account_name="myaccount")
>>> fs._strip_protocol("wasb://container/file")
'container/file'
>>> fs.split_path("wasb://container/file")
('container', 'file', None)
```

cc @kevinjqliu to confirm this works for pyiceberg