### PR TITLE
Move metadata fetching to get_metadata method

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -2056,14 +2056,16 @@ class AzureBlobFile(AbstractBufferedFile):
             self.offset = None
             self.forced = False
             self.location = None
+
     def get_metadata(self):
-            return self.metadata or sync(self.loop,
-                                         get_blob_metadata,
-                                         self.container_client,
-                                         self.blob,
-                                         version_id=self.version_id,
-                                        )
-            
+        return self.metadata or sync(
+            self.loop,
+            get_blob_metadata,
+            self.container_client,
+            self.blob,
+            version_id=self.version_id,
+        )
+
     def _get_loop(self):
         try:
             # Need to confirm there is an event loop running in


### PR DESCRIPTION
Refactor metadata retrieval into a separate method.  No reason to fetch metadata synchronously when creating the `AzureBlobFile` object.  Still enables metadata fetching using the new `get_metadata` method.

This saves about ~50ms per file open.

Generally synchronous calls are avoided without the user specifically requesting them. Therefore there is no reason to perform a sync call every time an object is created.