### PR TITLE
Update azure-core dependency version constraint

### DIFF
--- a/requirements/latest.txt
+++ b/requirements/latest.txt
@@ -1,5 +1,5 @@
 -r base.txt
 fsspec
-azure-core<2.0.0
+azure-core
 azure-datalake-store
 azure-storage-blob


### PR DESCRIPTION
There are 2 version naming schemes that are used by Azure (real version and by date). This causes many issues with conda environments.

I outlined the issue [here](https://github.com/Azure/azure-sdk-for-python/issues/43770) and [here](https://github.com/fsspec/adlfs/issues/522). Simply removing this constraint would fix the issue.

There is precedent for this. Look at `azure-storage-blob`. It does not have a maximum version, which allows it to be installed from either `azure-storage=2025.09.01` available [here](https://anaconda.org/channels/microsoft/packages/azure-storage/overview) or from the more specific `azure-storage-blob=12.27.1` available [here](https://anaconda.org/channels/conda-forge/packages/azure-storage-blob/overview).

Making this change would do a similar things for `azure-core=2025.09.01` ([here](https://anaconda.org/channels/microsoft/packages/azure-core/overview)) and `azure-core=1.36.0` ([here](https://anaconda.org/channels/conda-forge/packages/azure-core/overview))