### PR TITLE
capture version_id after upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Unreleased
 ----------
 - Added `**kwargs` to `AzureBlobFileSystem.exists()`
+- Populate `AzureBlobFile.version_id` on write when `version_aware` is enabled.
 
 2026.2.0
 --------
@@ -17,7 +18,6 @@ Unreleased
 - Added `AzureBlobFileSystem.rm_file()`
 - Keyword arguments for `put` and `put_file` are now proxied to the Azure Blob SDK client to 
   support specifying content settings, tags, and more.
-- Populate `AzureBlobFile.version_id` on write when `version_aware` is enabled.
 - Removed support for Python 3.9 and added support for Python 3.14.
 - Updated the azure-storage-blob dependency to include `aio` and removed the `aiohttp` dependency.
 - **Breaking:** Warning added for default anonymous use. By default, adlfs will require credentials starting

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1995,9 +1995,10 @@ class AzureBlobFile(AbstractBufferedFile):
             by `cache_type`.
 
         version_id : str
-            Optional version to read the file at.  If not specified this will
-            default to the current version of the object.  This is only used for
-            reading.
+            Optional version of the blob.  For reads, specifies which version to
+            read; if not given, defaults to the current version.  On write, this
+            attribute is populated with the version created by the upload when the
+            filesystem has ``version_aware=True``.
 
         kwargs: dict
             Passed to AbstractBufferedFile
@@ -2307,14 +2308,12 @@ class AzureBlobFile(AbstractBufferedFile):
                     raise RuntimeError(f"Failed to upload block: {e}!") from e
         elif self.mode == "ab":
             async with self.container_client.get_blob_client(blob=self.blob) as bc:
-                response = await bc.upload_blob(
+                await bc.upload_blob(
                     data=data,
                     length=length,
                     blob_type=BlobType.AppendBlob,
                     metadata=self.metadata,
                 )
-                if self.fs.version_aware:
-                    self.version_id = response.get("version_id")
         else:
             raise ValueError(
                 "File operation modes other than wb, xb or ab are not supported for upload_chunk"


### PR DESCRIPTION
Similar to https://github.com/fsspec/gcsfs/pull/718

To be able to refer to a file properly (in case multiple uploads happening simultaneously to the same path), we want to grab generation from the response. S3 already does this.