### PR TITLE
Remove upper bound for azure-datalake-store dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "azure-core>=1.28.0,<2.0.0",
-    "azure-datalake-store>=0.0.53,<0.1",
+    "azure-datalake-store>=0.0.53",
     "azure-identity",
     "azure-storage-blob>=12.17.0",
     "fsspec>=2023.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
     "azure-core>=1.28.0,<2.0.0",
-    "azure-datalake-store>=0.0.53",
+    "azure-datalake-store>=0.0.53,<2.0.0",
     "azure-identity",
     "azure-storage-blob>=12.17.0",
     "fsspec>=2023.12.0",


### PR DESCRIPTION
I noticed there is a 1.x.x release (June, 2025) of this dependency but this upper bound prevents it's usage. However, it is being tested against already (the latest.txt requirements are uncapped).