### PR TITLE
Update ADLS Gen 1 deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Unreleased
 ----------
 
+* Update ADLS Gen 1 deprecation warning to inform of removal of all ADLS Gen 1 features in an upcoming release.
+  If using ADLS Gen 1 interfaces, it is recommended to migrate to the `az://` protocol and/or
+  `adlfs.AzureBlobFileSystem` class which support Azure Blob Storage and Azure Data Lake Storage Gen2.
 * Lazy-load `metadata` property on `AzureBlobFile` to avoid fetching metadata on file open
   when it is not accessed.
 * Respect `AzureBlobFileSystem.protocol` tuple when removing protocols from fully-qualified

--- a/adlfs/gen1.py
+++ b/adlfs/gen1.py
@@ -63,8 +63,10 @@ class AzureDatalakeFileSystem(AbstractFileSystem):
 
     def __init__(self, tenant_id, client_id, client_secret, store_name):
         warn(
-            f"Microsoft has announced end of life for Azure Datalake Gen1.  {self.__class__.__name__}"
-            " will be moved to an optional install in a future release of adlfs",
+            "Azure Data Lake Storage (ADLS) Gen1 has been retired since February 29, 2024. "
+            "All ADLS Gen 1 features offered by adlfs will be removed in an upcoming release. "
+            "It is recommended to use the az:// protocol and/or adlfs.AzureBlobFileSystem class "
+            "which support Azure Blob Storage and Azure Data Lake Storage Gen2.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
Switched current deprecation warning on ADLS Gen 1 interfaces away from interfaces being offered as an optional dependency toward complete removal of functionality.

ADLS Gen 1 has been retired since February 2024 and it is not possible to create or access data with the service. This deprecation message will be included in at least one release of adlfs before all ADLS Gen 1 functionality is removed.

Confirmed deprecation message shows up when filesystem is instantiated e.g.:
```python
import fsspec

fsspec.filesystem(
    "adl",
    tenant_id="<tenant-id>",
    client_id="<client-id>",
    client_secret="<client-secret>",
    store_name="<store-name>",
)
```
Results in the warning message below when ran with all warnings enabled:
```
C:\Users\kyleknapp\GitHub\adlfs\.venv\Lib\site-packages\fsspec\spec.py:81: DeprecationWarning: Azure Data Lake Storage (ADLS) Gen1 has been retired since February 29, 2024. All ADLS Gen 1 features offered by adlfs will be removed in an upcoming release. It is recommended to use the az:// protocol and/or adlfs.AzureBlobFileSystem class which support Azure Blob Storage and Azure Data Lake Storage Gen2.
```