### PR TITLE
added aiohttp comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Unreleased
 * Keyword arguments for `put` and `put_file` are now proxied to the Azure Blob SDK client to 
   support specifying content settings, tags, and more.
 * Removed support for Python 3.9 and added support for Python 3.14.
+* Updated the azure-storage-blob dependency to include `aio` and removed the `aiohttp` dependency.
 
 2025.8.0
 --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,8 @@ dependencies = [
     "azure-core>=1.28.0,<2.0.0",
     "azure-datalake-store>=0.0.53,<0.1",
     "azure-identity",
-    "azure-storage-blob>=12.17.0",
+    "azure-storage-blob[aio]>=12.17.0",
     "fsspec>=2023.12.0",
-    # aiohttp is a required dependency for async operations when using azure-storage-blob
-    "aiohttp>=3.7.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Included the `aio` extra for the `azure-storage-blob` dependency and removed the `aiohttp` dependency to address github issue #452.