### PR TITLE
Extended type hint of credential field

### DIFF
--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -270,9 +270,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         account_name: str = None,
         account_key: str = None,
         connection_string: str = None,
-        credential: Optional[
-            Union[str, AsyncTokenCredential]
-        ] = None,
+        credential: Optional[Union[str, AsyncTokenCredential]] = None,
         sas_token: str = None,
         request_session=None,
         socket_timeout=_SOCKET_TIMEOUT_DEFAULT,


### PR DESCRIPTION
## Description
<!-- Provide a short summary of the changes in this PR. Explain the purpose, context, and any background information needed to understand the changes. -->
Extended type hint of credential field.
Included new import (`annotations from __future__`) to [fix F821 linting error](https://stackoverflow.com/questions/53605806/mypy-flake8-is-there-any-way-to-surpress-warning-of-f821-undefined-name/55550714#55550714) of undefined name in type hint 

- **Related Links**:
- [Github Issue](https://github.com/fsspec/adlfs/issues/525)


## Type of Change
<!-- Place an 'x' in the relevant box(es) -->

- [ ] Bug fix
- [ ] New feature
- [X] Documentation update 
- [ ] Code quality improvement
- [ ] Other (describe):
