### PR TITLE
Fixed files not getting deleted when mv() is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
 - Added `**kwargs` to `AzureBlobFileSystem.exists()`
 - Populate `AzureBlobFile.version_id` on write when `version_aware` is enabled.
 - Fixed issue where unawaitable Credential types were incorrectly awaited (#431)
-- Added `AzureBlobFileSystem.mv()` to address issue of files not being deleted when they are moved.
+- Fixed a bug where moving files does not delete them from the original location
 
 2026.2.0
 --------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Unreleased
 - Added `**kwargs` to `AzureBlobFileSystem.exists()`
 - Populate `AzureBlobFile.version_id` on write when `version_aware` is enabled.
 - Fixed issue where unawaitable Credential types were incorrectly awaited (#431)
-- Fixed a bug where moving files does not delete them from the original location
+- Fixed a bug where moving files does not delete them from the original location (#255)
 
 2026.2.0
 --------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Unreleased
 - Added `**kwargs` to `AzureBlobFileSystem.exists()`
 - Populate `AzureBlobFile.version_id` on write when `version_aware` is enabled.
 - Fixed issue where unawaitable Credential types were incorrectly awaited (#431)
+- Added `AzureBlobFileSystem.mv()` to address issue of files not being deleted when they are moved.
 
 2026.2.0
 --------

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1379,23 +1379,6 @@ class AzureBlobFileSystem(AsyncFileSystem):
             await self.service_client.delete_container(container_name)
             self.invalidate_cache(_ROOT_PATH)
 
-    async def _mv(self, path1, path2, recursive=False, maxdepth=None, **kwargs):
-        """Move file(s) from one location to another."""
-        if path1 == path2:
-            logger.debug("%s mv: The paths are the same, so no files were moved.", self)
-            return
-
-        is_dir = await self._isdir(path1)
-        if is_dir and not recursive:
-            recursive = True
-
-        await self._copy(
-            path1, path2, recursive=recursive, maxdepth=maxdepth, on_error="raise"
-        )
-        await self._rm(path1, recursive=recursive)
-
-    mv = sync_wrapper(_mv)
-
     def size(self, path):
         return sync(self.loop, self._size, path)
 

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1809,7 +1809,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         container1, blob1, version_id = self.split_path(path1, delimiter="/")
         container2, blob2, _ = self.split_path(path2, delimiter="/")
 
-        if await self._isdir(path1):
+        if version_id is None and await self._isdir(path1):
             return
 
         cc1 = self.service_client.get_container_client(container1)

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1340,21 +1340,19 @@ class AzureBlobFileSystem(AsyncFileSystem):
         A directory marker is an empty blob who's name is the path of the directory.
         """
         unique_sorted_file_paths = sorted(set(file_paths))  # Remove duplicates and sort
-        directory_markers = []
-        files = [
-            unique_sorted_file_paths[-1]
-        ]  # The last file lexographically cannot be a directory marker for a non-empty directory.
+        prefix_set = set()
+        for fp in unique_sorted_file_paths:
+            parts = fp.split("/")
+            for i in range(1, len(parts)):
+                prefix_set.add("/".join(parts[:i]))
 
-        for file, next_file in zip(
-            unique_sorted_file_paths, unique_sorted_file_paths[1:]
-        ):
-            # /path/to/directory -- directory marker
-            # /path/to/directory/file  -- file in directory
-            # /path/to/directory2/file -- file in different directory
-            if next_file.startswith(file + "/"):
-                directory_markers.append(file)
+        directory_markers = []
+        files = []
+        for fp in unique_sorted_file_paths:
+            if fp in prefix_set:
+                directory_markers.append(fp)
             else:
-                files.append(file)
+                files.append(fp)
 
         return files, directory_markers
 
@@ -1380,6 +1378,23 @@ class AzureBlobFileSystem(AsyncFileSystem):
         if container_exists and not path:
             await self.service_client.delete_container(container_name)
             self.invalidate_cache(_ROOT_PATH)
+
+    async def _mv(self, path1, path2, recursive=False, maxdepth=None, **kwargs):
+        """Move file(s) from one location to another."""
+        if path1 == path2:
+            logger.debug("%s mv: The paths are the same, so no files were moved.", self)
+            return
+
+        is_dir = await self._isdir(path1)
+        if is_dir and not recursive:
+            recursive = True
+
+        await self._copy(
+            path1, path2, recursive=recursive, maxdepth=maxdepth, on_error="raise"
+        )
+        await self._rm(path1, recursive=recursive)
+
+    mv = sync_wrapper(_mv)
 
     def size(self, path):
         return sync(self.loop, self._size, path)
@@ -1793,6 +1808,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
         """Copy the file at path1 to path2"""
         container1, blob1, version_id = self.split_path(path1, delimiter="/")
         container2, blob2, _ = self.split_path(path2, delimiter="/")
+
+        if await self._isdir(path1):
+            return
 
         cc1 = self.service_client.get_container_client(container1)
         blobclient1 = cc1.get_blob_client(blob=blob1)

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2552,11 +2552,11 @@ def test_mv_directory(storage):
 @pytest.mark.parametrize(
     "src_files,expected_dst_files",
     [
-        pytest.param(
+        (
             {"a/b/file.txt": b"test 1", "a/file.txt": b"test 2"},
             {"a/b/file.txt": b"test 1", "a/file.txt": b"test 2"},
         ),
-        pytest.param(
+        (
             {"a/file.txt": b"test 3", "a1/file.txt": b"test 4"},
             {"a/file.txt": b"test 3", "a1/file.txt": b"test 4"},
         ),

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2540,7 +2540,7 @@ def test_mv_directory(storage):
     with fs.open("mvcontainer/srcdir/file.txt", "wb") as f:
         f.write(b"hello")
 
-    fs.mv("mvcontainer/srcdir", "mvcontainer/dstdir/")
+    fs.mv("mvcontainer/srcdir", "mvcontainer/dstdir/", recursive=True)
 
     assert fs.exists("mvcontainer/dstdir/srcdir/file.txt")
     assert not fs.exists("mvcontainer/srcdir/")
@@ -2549,7 +2549,7 @@ def test_mv_directory(storage):
     fs.rm("mvcontainer", recursive=True)
 
 
-def test_mv_directory_structures(storage):
+def test_mv_nested_directories(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR
     )

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2511,3 +2511,72 @@ class TestCloseCredential:
     async def test_close_credential(self, credential):
         file_obj = SimpleNamespace(credential=credential)
         await close_credential(file_obj)
+
+
+def test_mv_single_file(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    fs.mkdir("mvcontainer")
+
+    with fs.open("mvcontainer/srcdir/file.txt", "wb") as f:
+        f.write(b"hello")
+
+    fs.mv("mvcontainer/srcdir/file.txt", "mvcontainer/dstdir/")
+
+    assert fs.exists("mvcontainer/dstdir/file.txt")
+    assert not fs.exists("mvcontainer/srcdir/file.txt")
+    assert fs.cat_file("mvcontainer/dstdir/file.txt") == b"hello"
+
+    fs.rm("mvcontainer", recursive=True)
+
+
+def test_mv_directory(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    fs.mkdir("mvcontainer")
+
+    with fs.open("mvcontainer/srcdir/file.txt", "wb") as f:
+        f.write(b"hello")
+
+    fs.mv("mvcontainer/srcdir", "mvcontainer/dstdir/")
+
+    assert fs.exists("mvcontainer/dstdir/srcdir/file.txt")
+    assert not fs.exists("mvcontainer/srcdir/")
+    assert fs.cat_file("mvcontainer/dstdir/srcdir/file.txt") == b"hello"
+
+    fs.rm("mvcontainer", recursive=True)
+
+
+@pytest.mark.parametrize(
+    "src_files,expected_dst_files",
+    [
+        pytest.param(
+            {"a/b/file.txt": b"test 1", "a/file.txt": b"test 2"},
+            {"a/b/file.txt": b"test 1", "a/file.txt": b"test 2"},
+        ),
+        pytest.param(
+            {"a/file.txt": b"test 3", "a1/file.txt": b"test 4"},
+            {"a/file.txt": b"test 3", "a1/file.txt": b"test 4"},
+        ),
+    ],
+)
+def test_mv_directory_structures(storage, src_files, expected_dst_files):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    fs.mkdir("mvcontainer")
+
+    for path, content in src_files.items():
+        with fs.open(f"mvcontainer/src/{path}", "wb") as f:
+            f.write(content)
+
+    fs.mv("mvcontainer/src/", "mvcontainer/dst/", recursive=True)
+
+    for path, content in expected_dst_files.items():
+        assert fs.exists(f"mvcontainer/dst/{path}")
+        assert fs.cat_file(f"mvcontainer/dst/{path}") == content
+        assert not fs.exists(f"mvcontainer/src/{path}")
+
+    fs.rm("mvcontainer", recursive=True)

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2549,34 +2549,19 @@ def test_mv_directory(storage):
     fs.rm("mvcontainer", recursive=True)
 
 
-@pytest.mark.parametrize(
-    "src_files,expected_dst_files",
-    [
-        (
-            {"a/b/file.txt": b"test 1", "a/file.txt": b"test 2"},
-            {"a/b/file.txt": b"test 1", "a/file.txt": b"test 2"},
-        ),
-        (
-            {"a/file.txt": b"test 3", "a1/file.txt": b"test 4"},
-            {"a/file.txt": b"test 3", "a1/file.txt": b"test 4"},
-        ),
-    ],
-)
-def test_mv_directory_structures(storage, src_files, expected_dst_files):
+def test_mv_directory_structures(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR
     )
     fs.mkdir("mvcontainer")
 
-    for path, content in src_files.items():
-        with fs.open(f"mvcontainer/src/{path}", "wb") as f:
-            f.write(content)
+    with fs.open("mvcontainer/a/b/c/file.txt", "wb") as f:
+        f.write(b"content")
 
-    fs.mv("mvcontainer/src/", "mvcontainer/dst/", recursive=True)
+    fs.mv("mvcontainer/a/b/c", "mvcontainer/a/c", recursive=True)
 
-    for path, content in expected_dst_files.items():
-        assert fs.exists(f"mvcontainer/dst/{path}")
-        assert fs.cat_file(f"mvcontainer/dst/{path}") == content
-        assert not fs.exists(f"mvcontainer/src/{path}")
+    assert fs.exists("mvcontainer/a/c/file.txt")
+    assert not fs.exists("mvcontainer/a/b/c")
+    assert fs.cat_file("mvcontainer/a/c/file.txt") == b"content"
 
     fs.rm("mvcontainer", recursive=True)


### PR DESCRIPTION
Fixed the issue of directories not getting deleted from the original location when moving them. This resolves #255. 