### PR TITLE
added maxdepth to find()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Unreleased
 ----------
-- .
+- Added the `maxdepth` parameter to `find()` (#435)
 
 2026.5.0
 --------

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -963,7 +963,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
 
         return output
 
-    async def _find(self, path, withdirs=False, prefix="", **kwargs):
+    async def _find(self, path, withdirs=False, prefix="", maxdepth=None, **kwargs):
         """List all files below path.
         Like posix ``find`` command without conditions.
 
@@ -976,6 +976,8 @@ class AzureBlobFileSystem(AsyncFileSystem):
             when used by glob, but users usually only want files.
         prefix: str
             Only return files that match `^{path}/{prefix}`
+        maxdepth: int or None
+            Maximum depth to recurse.
         kwargs are passed to ``ls``.
         """
         full_path = self._strip_protocol(path)
@@ -1037,6 +1039,15 @@ class AzureBlobFileSystem(AsyncFileSystem):
         if withdirs:
             files.update(dirs)
         files = {k: v for k, v in files.items() if k.startswith(target_path)}
+
+        if maxdepth is not None:
+            base_depth = full_path.rstrip("/").count("/")
+            files = {
+                k: v
+                for k, v in files.items()
+                if k.rstrip("/").count("/") <= base_depth + maxdepth
+            }
+
         names = sorted([n for n in files.keys()])
         if not detail:
             return names

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2610,3 +2610,26 @@ def test_etag_normalized_form(storage):
 )
 def test_striping_etag(input_etag, expected_etag):
     assert _normalize_etag_quotes(input_etag) == expected_etag
+
+
+def test_find_maxdepth(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+    )
+
+    assert fs.find("data/root", maxdepth=1) == ["data/root/rfile.txt"]
+
+    assert fs.find("data/root", maxdepth=1, withdirs=True) == [
+        "data/root/a",
+        "data/root/a1",
+        "data/root/b",
+        "data/root/c",
+        "data/root/d",
+        "data/root/e+f",
+        "data/root/rfile.txt",
+    ]
+
+    assert fs.find("data/root", maxdepth=2) == fs.find("data/root")
+
+    assert fs.find("data/root", maxdepth=None) == fs.find("data/root")


### PR DESCRIPTION
Added the `maxdepth` parameter to `find()` to be consistent with fsspec. This resolves #435. 