### PR TITLE
Fixed passing an empty list to rm()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Unreleased
 ----------
-- .
+- Fixed issue where calling rm() on an empty list returns an error (#363)
 
 2026.5.0
 --------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Unreleased
 ----------
-- Fixed issue where calling rm() on an empty list returns an error (#363)
+- Fixed issue where calling `rm()` on an empty list returns an error (#363)
 
 2026.5.0
 --------

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1233,7 +1233,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         """
         if isinstance(path, list) and len(path) == 0:
             return
-        
+
         if expand_path:
             path = await self._expand_path(
                 path,

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1231,6 +1231,9 @@ class AzureBlobFileSystem(AsyncFileSystem):
             If False, `self._expand_path` call will be skipped. This is more
             efficient when you don't need the operation.
         """
+        if isinstance(path, list) and len(path) == 0:
+            return
+        
         if expand_path:
             path = await self._expand_path(
                 path,

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2610,3 +2610,12 @@ def test_etag_normalized_form(storage):
 )
 def test_striping_etag(input_etag, expected_etag):
     assert _normalize_etag_quotes(input_etag) == expected_etag
+
+
+def test_rm_empty_list(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+    )
+    
+    fs.rm([])

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2617,5 +2617,5 @@ def test_rm_empty_list(storage):
         account_name=storage.account_name,
         connection_string=CONN_STR,
     )
-    
+
     fs.rm([])


### PR DESCRIPTION
Fixed an issue when an error is raised when an empty list is passed into `rm()`. This resolves #363. 