### PR TITLE
Fixed ls() bug when files have the same prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Unreleased
 ----------
-- .
+- Fixed `ls()` returning incorrect results when a file shares the same prefix as other files in the same directory (#409)
 
 2026.5.0
 --------

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -946,13 +946,16 @@ class AzureBlobFileSystem(AsyncFileSystem):
                 data["name"] = data["name"].rstrip("/")
             output.append(data)
         if target_path:
-            if (
-                len(output) == 1
-                and output[0]["type"] == "file"
-                and not self.version_aware
-            ):
-                # This handles the case where path is a file passed to ls
-                return output
+            if not self.version_aware:
+                # This handles the case where a file path is passed to ls and there are
+                # multiple files with the same prefix.
+                file = [
+                    o
+                    for o in output
+                    if o["name"] == target_path and o["type"] == "file"
+                ]
+                if file:
+                    return file
             output = await filter_blobs(
                 output,
                 target_path,

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2610,3 +2610,20 @@ def test_etag_normalized_form(storage):
 )
 def test_striping_etag(input_etag, expected_etag):
     assert _normalize_etag_quotes(input_etag) == expected_etag
+
+
+def test_ls_files_with_same_prefix(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name,
+        connection_string=CONN_STR,
+    )
+    path1 = "data/test/file.txt"
+    path2 = "data/test/file.txt.1"
+    fs.touch(path1)
+    fs.touch(path2)
+
+    assert fs.ls("data/test/") == [path1, path2]
+    assert fs.ls("data/test/file.txt") == [path1]
+    assert fs.ls("data/test/file.txt.1") == [path2]
+
+    fs.rm("data/test", recursive=True)


### PR DESCRIPTION
This addresses a bug where a filepath is passed into `ls()` and it shares the same prefix as other files in the same directory resulting in incorrect results. This resolves #406 and resolves #409.