### PR TITLE
Forward content_settings on write (open, pipe_file, put_file)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 Unreleased
 ----------
-- .
+- Added a `content_settings` parameter to `open()` (write modes), `pipe_file()` and `put_file()` to set blob content settings (content type, content disposition, cache control, ...) on write. Accepts a `dict` (recommended) or an `azure.storage.blob.ContentSettings` instance. [#554](https://github.com/fsspec/adlfs/pull/554)
+- Allow overriding blob `metadata` in `pipe_file()` and `put_file()` instead of always writing `{"is_directory": "false"}`. [#554](https://github.com/fsspec/adlfs/pull/554)
 
 2026.5.0
 --------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 Unreleased
 ----------
 - Added a `content_settings` parameter to `open()` (write modes), `pipe_file()` and `put_file()` to set blob content settings (content type, content disposition, cache control, ...) on write. Accepts a `dict` (recommended) or an `azure.storage.blob.ContentSettings` instance. [#554](https://github.com/fsspec/adlfs/pull/554)
-- Allow overriding blob `metadata` in `pipe_file()` and `put_file()` instead of always writing `{"is_directory": "false"}`. [#554](https://github.com/fsspec/adlfs/pull/554)
 
 2026.5.0
 --------

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -1519,7 +1519,6 @@ class AzureBlobFileSystem(AsyncFileSystem):
         """Set the bytes of given file"""
         if kwargs.pop("mode", "") == "create":
             overwrite = False
-        metadata = kwargs.pop("metadata", None) or {"is_directory": "false"}
         content_settings = _as_content_settings(kwargs.pop("content_settings", None))
         container_name, path, _ = self.split_path(path)
         async with self.service_client.get_blob_client(
@@ -1529,7 +1528,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                 result = await bc.upload_blob(
                     data=value,
                     overwrite=overwrite,
-                    metadata=metadata,
+                    metadata={"is_directory": "false"},
                     content_settings=content_settings,
                     max_concurrency=max_concurrency or self.max_concurrency,
                     **self._timeout_kwargs,
@@ -1761,7 +1760,6 @@ class AzureBlobFileSystem(AsyncFileSystem):
 
         if kwargs.pop("mode", "") == "create":
             overwrite = False
-        metadata = kwargs.pop("metadata", None) or {"is_directory": "false"}
         content_settings = _as_content_settings(kwargs.pop("content_settings", None))
         container_name, path, _ = self.split_path(rpath, delimiter=delimiter)
 
@@ -1776,7 +1774,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                         await bc.upload_blob(
                             f1,
                             overwrite=overwrite,
-                            metadata=metadata,
+                            metadata={"is_directory": "false"},
                             content_settings=content_settings,
                             raw_response_hook=make_callback(
                                 "upload_stream_current", callback

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -164,6 +164,19 @@ def _normalize_etag_quotes(etag: str) -> Optional[str]:
     return f'"{etag.strip(double_quote)}"'
 
 
+def _as_content_settings(
+    content_settings: Optional[Union[ContentSettings, dict]],
+) -> Optional[ContentSettings]:
+    """Coerce ``content_settings`` given as a dict into a ``ContentSettings``.
+
+    Accepts either a plain ``dict`` (recommended — keeps the Azure SDK out of the
+    caller's imports) or a ``ContentSettings`` instance.
+    """
+    if content_settings is None or isinstance(content_settings, ContentSettings):
+        return content_settings
+    return ContentSettings(**content_settings)
+
+
 class AzureBlobFileSystem(AsyncFileSystem):
     """
     Access Azure Datalake Gen2 and Azure Storage if it were a file system using Multiprotocol Access
@@ -1507,6 +1520,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         if kwargs.pop("mode", "") == "create":
             overwrite = False
         metadata = kwargs.pop("metadata", None) or {"is_directory": "false"}
+        content_settings = _as_content_settings(kwargs.pop("content_settings", None))
         container_name, path, _ = self.split_path(path)
         async with self.service_client.get_blob_client(
             container=container_name, blob=path
@@ -1516,6 +1530,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                     data=value,
                     overwrite=overwrite,
                     metadata=metadata,
+                    content_settings=content_settings,
                     max_concurrency=max_concurrency or self.max_concurrency,
                     **self._timeout_kwargs,
                     **kwargs,
@@ -1747,6 +1762,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         if kwargs.pop("mode", "") == "create":
             overwrite = False
         metadata = kwargs.pop("metadata", None) or {"is_directory": "false"}
+        content_settings = _as_content_settings(kwargs.pop("content_settings", None))
         container_name, path, _ = self.split_path(rpath, delimiter=delimiter)
 
         if os.path.isdir(lpath):
@@ -1761,6 +1777,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                             f1,
                             overwrite=overwrite,
                             metadata=metadata,
+                            content_settings=content_settings,
                             raw_response_hook=make_callback(
                                 "upload_stream_current", callback
                             ),
@@ -1902,7 +1919,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         cache_type="readahead",
         metadata=None,
         version_id: Optional[str] = None,
-        content_settings: Optional[ContentSettings] = None,
+        content_settings: Optional[Union[ContentSettings, dict]] = None,
         **kwargs,
     ):
         """Open a file on the datalake, or a block blob
@@ -1932,9 +1949,10 @@ class AzureBlobFileSystem(AsyncFileSystem):
             Explicit version of the blob to open.  This requires that the abfs filesystem
             is versioning aware and blob versioning is enabled on the releveant container.
 
-        content_settings: ContentSettings
-            Optional content settings (content type, content disposition, cache
-            control, ...) applied to the blob when writing.
+        content_settings: dict
+            Optional content settings applied to the blob when writing, e.g.
+            ``{"content_type": "application/pdf", "content_disposition": "..."}``.
+            A ``ContentSettings`` instance is also accepted.
         """
         logger.debug(f"_open:  {path}")
         if block_size is None:
@@ -1975,7 +1993,7 @@ class AzureBlobFile(AbstractBufferedFile):
         cache_options: dict = {},
         metadata=None,
         version_id: Optional[str] = None,
-        content_settings: Optional[ContentSettings] = None,
+        content_settings: Optional[Union[ContentSettings, dict]] = None,
         **kwargs,
     ):
         """
@@ -2013,9 +2031,10 @@ class AzureBlobFile(AbstractBufferedFile):
             attribute is populated with the version created by the upload when the
             filesystem has ``version_aware=True``.
 
-        content_settings: ContentSettings
-            Optional content settings (content type, content disposition, cache
-            control, ...) applied to the blob when writing.
+        content_settings: dict
+            Optional content settings applied to the blob when writing, e.g.
+            ``{"content_type": "application/pdf", "content_disposition": "..."}``.
+            A ``ContentSettings`` instance is also accepted.
 
         kwargs: dict
             Passed to AbstractBufferedFile
@@ -2087,7 +2106,7 @@ class AzureBlobFile(AbstractBufferedFile):
 
         else:
             self._metadata = metadata or {"is_directory": "false"}
-            self.content_settings = content_settings
+            self._content_settings = _as_content_settings(content_settings)
             self.buffer = io.BytesIO()
             self.offset = None
             self.forced = False
@@ -2226,7 +2245,7 @@ class AzureBlobFile(AbstractBufferedFile):
                 async with self.container_client.get_blob_client(blob=self.blob) as bc:
                     await bc.create_append_blob(
                         metadata=self.metadata,
-                        content_settings=self.content_settings,
+                        content_settings=self._content_settings,
                     )
 
     _initiate_upload = sync_wrapper(_async_initiate_upload)
@@ -2289,7 +2308,7 @@ class AzureBlobFile(AbstractBufferedFile):
                         response = await bc.commit_block_list(
                             block_list=block_list,
                             metadata=self.metadata,
-                            content_settings=self.content_settings,
+                            content_settings=self._content_settings,
                             **commit_kw,
                         )
                         if self.fs.version_aware:
@@ -2308,7 +2327,7 @@ class AzureBlobFile(AbstractBufferedFile):
                         response = await bc.upload_blob(
                             data=data,
                             metadata=self.metadata,
-                            content_settings=self.content_settings,
+                            content_settings=self._content_settings,
                             overwrite=(self.mode == "wb"),
                         )
                         if self.fs.version_aware:
@@ -2323,7 +2342,7 @@ class AzureBlobFile(AbstractBufferedFile):
                             response = await bc.commit_block_list(
                                 block_list=block_list,
                                 metadata=self.metadata,
-                                content_settings=self.content_settings,
+                                content_settings=self._content_settings,
                                 **commit_kw,
                             )
                             if self.fs.version_aware:

--- a/adlfs/spec.py
+++ b/adlfs/spec.py
@@ -31,6 +31,7 @@ from azure.storage.blob import (
     BlobProperties,
     BlobSasPermissions,
     BlobType,
+    ContentSettings,
     generate_blob_sas,
 )
 from azure.storage.blob.aio import BlobPrefix
@@ -1505,6 +1506,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         """Set the bytes of given file"""
         if kwargs.pop("mode", "") == "create":
             overwrite = False
+        metadata = kwargs.pop("metadata", None) or {"is_directory": "false"}
         container_name, path, _ = self.split_path(path)
         async with self.service_client.get_blob_client(
             container=container_name, blob=path
@@ -1513,7 +1515,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                 result = await bc.upload_blob(
                     data=value,
                     overwrite=overwrite,
-                    metadata={"is_directory": "false"},
+                    metadata=metadata,
                     max_concurrency=max_concurrency or self.max_concurrency,
                     **self._timeout_kwargs,
                     **kwargs,
@@ -1744,6 +1746,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
 
         if kwargs.pop("mode", "") == "create":
             overwrite = False
+        metadata = kwargs.pop("metadata", None) or {"is_directory": "false"}
         container_name, path, _ = self.split_path(rpath, delimiter=delimiter)
 
         if os.path.isdir(lpath):
@@ -1757,7 +1760,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
                         await bc.upload_blob(
                             f1,
                             overwrite=overwrite,
-                            metadata={"is_directory": "false"},
+                            metadata=metadata,
                             raw_response_hook=make_callback(
                                 "upload_stream_current", callback
                             ),
@@ -1899,6 +1902,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
         cache_type="readahead",
         metadata=None,
         version_id: Optional[str] = None,
+        content_settings: Optional[ContentSettings] = None,
         **kwargs,
     ):
         """Open a file on the datalake, or a block blob
@@ -1927,6 +1931,10 @@ class AzureBlobFileSystem(AsyncFileSystem):
         version_id: str
             Explicit version of the blob to open.  This requires that the abfs filesystem
             is versioning aware and blob versioning is enabled on the releveant container.
+
+        content_settings: ContentSettings
+            Optional content settings (content type, content disposition, cache
+            control, ...) applied to the blob when writing.
         """
         logger.debug(f"_open:  {path}")
         if block_size is None:
@@ -1946,6 +1954,7 @@ class AzureBlobFileSystem(AsyncFileSystem):
             cache_type=cache_type,
             metadata=metadata,
             version_id=version_id,
+            content_settings=content_settings,
             **kwargs,
         )
 
@@ -1966,6 +1975,7 @@ class AzureBlobFile(AbstractBufferedFile):
         cache_options: dict = {},
         metadata=None,
         version_id: Optional[str] = None,
+        content_settings: Optional[ContentSettings] = None,
         **kwargs,
     ):
         """
@@ -2002,6 +2012,10 @@ class AzureBlobFile(AbstractBufferedFile):
             read; if not given, defaults to the current version.  On write, this
             attribute is populated with the version created by the upload when the
             filesystem has ``version_aware=True``.
+
+        content_settings: ContentSettings
+            Optional content settings (content type, content disposition, cache
+            control, ...) applied to the blob when writing.
 
         kwargs: dict
             Passed to AbstractBufferedFile
@@ -2073,6 +2087,7 @@ class AzureBlobFile(AbstractBufferedFile):
 
         else:
             self._metadata = metadata or {"is_directory": "false"}
+            self.content_settings = content_settings
             self.buffer = io.BytesIO()
             self.offset = None
             self.forced = False
@@ -2209,7 +2224,10 @@ class AzureBlobFile(AbstractBufferedFile):
         if self.mode == "ab":
             if not await self.fs._exists(self.path):
                 async with self.container_client.get_blob_client(blob=self.blob) as bc:
-                    await bc.create_append_blob(metadata=self.metadata)
+                    await bc.create_append_blob(
+                        metadata=self.metadata,
+                        content_settings=self.content_settings,
+                    )
 
     _initiate_upload = sync_wrapper(_async_initiate_upload)
 
@@ -2269,7 +2287,10 @@ class AzureBlobFile(AbstractBufferedFile):
                         blob=self.blob
                     ) as bc:
                         response = await bc.commit_block_list(
-                            block_list=block_list, metadata=self.metadata, **commit_kw
+                            block_list=block_list,
+                            metadata=self.metadata,
+                            content_settings=self.content_settings,
+                            **commit_kw,
                         )
                         if self.fs.version_aware:
                             self.version_id = response.get("version_id")
@@ -2287,6 +2308,7 @@ class AzureBlobFile(AbstractBufferedFile):
                         response = await bc.upload_blob(
                             data=data,
                             metadata=self.metadata,
+                            content_settings=self.content_settings,
                             overwrite=(self.mode == "wb"),
                         )
                         if self.fs.version_aware:
@@ -2301,6 +2323,7 @@ class AzureBlobFile(AbstractBufferedFile):
                             response = await bc.commit_block_list(
                                 block_list=block_list,
                                 metadata=self.metadata,
+                                content_settings=self.content_settings,
                                 **commit_kw,
                             )
                             if self.fs.version_aware:

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1464,18 +1464,13 @@ def test_content_settings_pipe_file(storage):
         account_name=storage.account_name, connection_string=CONN_STR
     )
     fs.mkdir("test-cs-pipe")
-    # content settings and custom metadata together
     fs.pipe_file(
-        "test-cs-pipe/piped.pdf",
-        b"0123456789",
-        content_settings=CONTENT_SETTINGS,
-        metadata={"origin": "adlfs-test"},
+        "test-cs-pipe/piped.pdf", b"0123456789", content_settings=CONTENT_SETTINGS
     )
     info = fs.info("test-cs-pipe/piped.pdf")
     assert info["content_settings"]["content_disposition"] == (
         'attachment; filename="f.pdf"'
     )
-    assert info["metadata"] == {"origin": "adlfs-test"}
     assert fs.cat_file("test-cs-pipe/piped.pdf") == b"0123456789"
     fs.rmdir("test-cs-pipe")
 
@@ -1487,16 +1482,9 @@ def test_content_settings_put_file(storage, tmp_path):
     fs.mkdir("test-cs-put")
     local = tmp_path / "f.pdf"
     local.write_bytes(b"0123456789")
-    # content settings and custom metadata (override the is_directory default)
-    fs.put_file(
-        str(local),
-        "test-cs-put/put.pdf",
-        content_settings=CONTENT_SETTINGS,
-        metadata={"origin": "adlfs-test"},
-    )
+    fs.put_file(str(local), "test-cs-put/put.pdf", content_settings=CONTENT_SETTINGS)
     info = fs.info("test-cs-put/put.pdf")
     assert info["content_settings"]["content_type"] == "application/pdf"
-    assert info["metadata"] == {"origin": "adlfs-test"}
     assert fs.cat_file("test-cs-put/put.pdf") == b"0123456789"
     fs.rmdir("test-cs-put")
 

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1413,55 +1413,111 @@ def test_metadata_write(storage):
     fs.rmdir("test-metadata-write")
 
 
-def test_content_settings_write(storage):
-    from azure.storage.blob import ContentSettings
+CONTENT_SETTINGS = {
+    "content_type": "application/pdf",
+    "content_disposition": 'attachment; filename="f.pdf"',
+    "cache_control": "max-age=3600",
+}
 
+
+def test_content_settings_open(storage):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR
     )
-    fs.mkdir("test-content-settings")
-    data = b"0123456789"
-    settings = ContentSettings(
-        content_type="application/pdf",
-        content_disposition='attachment; filename="f.pdf"',
-        cache_control="max-age=3600",
-    )
-
-    # streaming write (block blob)
-    with fs.open(
-        "test-content-settings/file.pdf", "wb", content_settings=settings
-    ) as f:
-        f.write(data)
-    cs = fs.info("test-content-settings/file.pdf")["content_settings"]
+    fs.mkdir("test-cs-open")
+    with fs.open("test-cs-open/file.pdf", "wb", content_settings=CONTENT_SETTINGS) as f:
+        f.write(b"0123456789")
+    cs = fs.info("test-cs-open/file.pdf")["content_settings"]
     assert cs["content_type"] == "application/pdf"
     assert cs["content_disposition"] == 'attachment; filename="f.pdf"'
     assert cs["cache_control"] == "max-age=3600"
 
     # empty streaming write still applies content settings
     with fs.open(
-        "test-content-settings/empty.pdf", "wb", content_settings=settings
+        "test-cs-open/empty.pdf", "wb", content_settings=CONTENT_SETTINGS
     ) as f:
         f.write(b"")
     assert (
-        fs.info("test-content-settings/empty.pdf")["content_settings"]["content_type"]
+        fs.info("test-cs-open/empty.pdf")["content_settings"]["content_type"]
         == "application/pdf"
     )
+    fs.rmdir("test-cs-open")
 
-    # pipe_file carries content settings and custom metadata together
+
+def test_content_settings_append(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    fs.mkdir("test-cs-append")
+    with fs.open(
+        "test-cs-append/file.pdf", "ab", content_settings=CONTENT_SETTINGS
+    ) as f:
+        f.write(b"0123456789")
+    cs = fs.info("test-cs-append/file.pdf")["content_settings"]
+    assert cs["content_type"] == "application/pdf"
+    assert cs["content_disposition"] == 'attachment; filename="f.pdf"'
+    fs.rmdir("test-cs-append")
+
+
+def test_content_settings_pipe_file(storage):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    fs.mkdir("test-cs-pipe")
+    # content settings and custom metadata together
     fs.pipe_file(
-        "test-content-settings/piped.pdf",
-        data,
-        content_settings=settings,
+        "test-cs-pipe/piped.pdf",
+        b"0123456789",
+        content_settings=CONTENT_SETTINGS,
         metadata={"origin": "adlfs-test"},
     )
-    info = fs.info("test-content-settings/piped.pdf")
+    info = fs.info("test-cs-pipe/piped.pdf")
     assert info["content_settings"]["content_disposition"] == (
         'attachment; filename="f.pdf"'
     )
     assert info["metadata"] == {"origin": "adlfs-test"}
-    assert fs.cat_file("test-content-settings/piped.pdf") == data
+    assert fs.cat_file("test-cs-pipe/piped.pdf") == b"0123456789"
+    fs.rmdir("test-cs-pipe")
 
-    fs.rmdir("test-content-settings")
+
+def test_content_settings_put_file(storage, tmp_path):
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    fs.mkdir("test-cs-put")
+    local = tmp_path / "f.pdf"
+    local.write_bytes(b"0123456789")
+    # content settings and custom metadata (override the is_directory default)
+    fs.put_file(
+        str(local),
+        "test-cs-put/put.pdf",
+        content_settings=CONTENT_SETTINGS,
+        metadata={"origin": "adlfs-test"},
+    )
+    info = fs.info("test-cs-put/put.pdf")
+    assert info["content_settings"]["content_type"] == "application/pdf"
+    assert info["metadata"] == {"origin": "adlfs-test"}
+    assert fs.cat_file("test-cs-put/put.pdf") == b"0123456789"
+    fs.rmdir("test-cs-put")
+
+
+def test_content_settings_accepts_object(storage):
+    # A ContentSettings instance is accepted for compatibility (dict is the
+    # documented form).
+    from azure.storage.blob import ContentSettings
+
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    fs.mkdir("test-cs-object")
+    settings = ContentSettings(content_type="application/pdf")
+    with fs.open("test-cs-object/obj.pdf", "wb", content_settings=settings) as f:
+        f.write(b"x")
+    assert (
+        fs.info("test-cs-object/obj.pdf")["content_settings"]["content_type"]
+        == "application/pdf"
+    )
+    fs.rmdir("test-cs-object")
 
 
 def test_put_file(storage, tmp_path):

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -2119,6 +2119,7 @@ async def test_pipe_file_timeout(storage, mocker):
     upload_blob.assert_called_once_with(
         data=b"data",
         metadata={"is_directory": "false"},
+        content_settings=None,
         overwrite=True,
         max_concurrency=fs.max_concurrency,
         timeout=11,
@@ -2147,6 +2148,7 @@ async def test_put_file_timeout(storage, mocker, tmp_path):
     upload_blob.assert_called_once_with(
         mocker.ANY,
         metadata={"is_directory": "false"},
+        content_settings=None,
         overwrite=True,
         raw_response_hook=None,
         max_concurrency=fs.max_concurrency,

--- a/adlfs/tests/test_spec.py
+++ b/adlfs/tests/test_spec.py
@@ -1413,6 +1413,57 @@ def test_metadata_write(storage):
     fs.rmdir("test-metadata-write")
 
 
+def test_content_settings_write(storage):
+    from azure.storage.blob import ContentSettings
+
+    fs = AzureBlobFileSystem(
+        account_name=storage.account_name, connection_string=CONN_STR
+    )
+    fs.mkdir("test-content-settings")
+    data = b"0123456789"
+    settings = ContentSettings(
+        content_type="application/pdf",
+        content_disposition='attachment; filename="f.pdf"',
+        cache_control="max-age=3600",
+    )
+
+    # streaming write (block blob)
+    with fs.open(
+        "test-content-settings/file.pdf", "wb", content_settings=settings
+    ) as f:
+        f.write(data)
+    cs = fs.info("test-content-settings/file.pdf")["content_settings"]
+    assert cs["content_type"] == "application/pdf"
+    assert cs["content_disposition"] == 'attachment; filename="f.pdf"'
+    assert cs["cache_control"] == "max-age=3600"
+
+    # empty streaming write still applies content settings
+    with fs.open(
+        "test-content-settings/empty.pdf", "wb", content_settings=settings
+    ) as f:
+        f.write(b"")
+    assert (
+        fs.info("test-content-settings/empty.pdf")["content_settings"]["content_type"]
+        == "application/pdf"
+    )
+
+    # pipe_file carries content settings and custom metadata together
+    fs.pipe_file(
+        "test-content-settings/piped.pdf",
+        data,
+        content_settings=settings,
+        metadata={"origin": "adlfs-test"},
+    )
+    info = fs.info("test-content-settings/piped.pdf")
+    assert info["content_settings"]["content_disposition"] == (
+        'attachment; filename="f.pdf"'
+    )
+    assert info["metadata"] == {"origin": "adlfs-test"}
+    assert fs.cat_file("test-content-settings/piped.pdf") == data
+
+    fs.rmdir("test-content-settings")
+
+
 def test_put_file(storage, tmp_path):
     fs = AzureBlobFileSystem(
         account_name=storage.account_name, connection_string=CONN_STR


### PR DESCRIPTION
Note: AI was heavily used to generate this. I reviewed the design principle and discussions on this topic across fsspec implementations.

## Problem

`AzureBlobFile` only forwards `metadata` when committing a write — it drops content settings entirely. So there is no way to set `content_type` / `content_disposition` / `cache_control` / `content_encoding` when writing a blob through `fs.open(..., "wb")`, `pipe_file`, or `put_file`, even though the Azure SDK's `commit_block_list` / `upload_blob` / `create_append_blob` accept `content_settings`. This makes adlfs inconsistent with `s3fs` (extra kwargs → `s3_additional_kwargs`) and `gcsfs` (`content_type` / `fixed_key_metadata`), which set these inline in the atomic write.

## Change

Add a `content_settings` parameter to `open()` (write modes), `pipe_file()`, and `put_file()`, applied **atomically** as part of the write commit (block, empty, and append blobs) — not a separate follow-up request.

To keep the Azure SDK out of the caller's imports, the documented/typed form is a plain `dict`; an `azure.storage.blob.ContentSettings` instance is also accepted for convenience.

```python
import fsspec

with fsspec.open(
    "abfs://cont/report.pdf",
    mode="wb",
    content_settings={
        "content_type": "application/pdf",
        "content_disposition": 'attachment; filename="report.pdf"',
        "cache_control": "max-age=3600",
    },
    account_name="myaccount",
    connection_string=CONN_STR,
) as f:
    f.write(data)

# also works with pipe_file / put_file
fs.pipe_file("cont/x.pdf", data, content_settings={"content_type": "application/pdf"})
```

## Notes

- Scoped to content settings only. An earlier revision also let `pipe_file`/`put_file` override the hard-coded `metadata={"is_directory": "false"}`; that's unrelated to content settings (and metadata is already settable via `fs.open(metadata=...)`), so it was reverted.
- Deferred, per discussion: no top-level `content_type=` kwarg for now — better introduced once the fsspec implementations converge on a shared interface (see [filesystem_spec#916](https://github.com/fsspec/filesystem_spec/issues/916)); a top-level field can be added alongside `content_settings` later.

## Tests

Per-method tests (verified against azurite):
- `test_content_settings_open` — streaming `open("wb")` + empty write
- `test_content_settings_append` — `open("ab")` (append blob)
- `test_content_settings_pipe_file` — `pipe_file`
- `test_content_settings_put_file` — `put_file`
- `test_content_settings_accepts_object` — a `ContentSettings` instance is accepted

Each verifies the settings round-trip via `fs.info(...)["content_settings"]`. Existing `test_pipe_file_timeout` / `test_put_file_timeout` updated for the new `content_settings` kwarg.
